### PR TITLE
(Ready for review) Support for beautiful relative imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS X
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Join our slack group: https://pyt-dev.slack.com/
 
 Create a directory to hold the virtual env and project
 
-`mkdir ~/pyt`
+`mkdir ~/a_folder`
 
-`cd ~/pyt`
+`cd ~/a_folder`
 
 Clone the project into the directory
 
@@ -40,13 +40,13 @@ Clone the project into the directory
 
 Create the virtual environment
 
-`python3 -m venv ~/pyt/`
+`python3 -m venv ~/a_folder/`
 
 Check that you have the right versions
 
 `python --version` sample output `Python 3.6.0`
 
-`pip --version` sample output `pip 9.0.1 from /Users/kevinhock/pyt/lib/python3.6/site-packages (python 3.6)`
+`pip --version` sample output `pip 9.0.1 from /Users/kevinhock/a_folder/lib/python3.6/site-packages (python 3.6)`
 
 Change to project directory
 

--- a/example/import_test_project/A.py
+++ b/example/import_test_project/A.py
@@ -1,2 +1,8 @@
 def B(s):
     return s
+
+def C(s):
+    return s + "see"
+
+def D(s):
+    return s + "dee"

--- a/example/import_test_project/all.py
+++ b/example/import_test_project/all.py
@@ -1,0 +1,6 @@
+from all_folder.has_all import *
+
+
+LemonGrass()
+# MangoYuzu is not defined because it is not in __all__
+MangoYuzu()

--- a/example/import_test_project/all_folder/has_all.py
+++ b/example/import_test_project/all_folder/has_all.py
@@ -1,0 +1,9 @@
+__all__ = [
+    'LemonGrass'
+]
+
+def LemonGrass():
+    print ('LemonGrass')
+
+def MangoYuzu():
+    print ('MangoYuzu')

--- a/example/import_test_project/all_folder/no_all.py
+++ b/example/import_test_project/all_folder/no_all.py
@@ -1,0 +1,5 @@
+def _LemonGrass():
+    print ('LemonGrass')
+
+def MangoYuzu():
+    print ('MangoYuzu')

--- a/example/import_test_project/foo/bar.py
+++ b/example/import_test_project/foo/bar.py
@@ -1,2 +1,2 @@
 def H(s):
-    return s
+    return s + "end"

--- a/example/import_test_project/foo/bar.py
+++ b/example/import_test_project/foo/bar.py
@@ -1,0 +1,2 @@
+def H(s):
+    return s

--- a/example/import_test_project/from_directory.py
+++ b/example/import_test_project/from_directory.py
@@ -1,0 +1,3 @@
+from foo import bar
+
+bar.H('hey')

--- a/example/import_test_project/from_dot.py
+++ b/example/import_test_project/from_dot.py
@@ -1,0 +1,4 @@
+from . import A
+
+
+c = A.B('sss')

--- a/example/import_test_project/import.py
+++ b/example/import_test_project/import.py
@@ -1,6 +1,4 @@
 from A import B
 import A
-import D
 b = B('str')
 c = A.B('sss')
-d = D.a('hey')

--- a/example/import_test_project/import_as.py
+++ b/example/import_test_project/import_as.py
@@ -1,0 +1,4 @@
+from A import B
+import A as foo
+b = B('str')
+c = foo.B('sss')

--- a/example/import_test_project/init.py
+++ b/example/import_test_project/init.py
@@ -1,0 +1,4 @@
+import init_file_folder
+
+
+init_file_folder.Eataly()

--- a/example/import_test_project/init_file_folder/__init__.py
+++ b/example/import_test_project/init_file_folder/__init__.py
@@ -1,0 +1,1 @@
+from .nested_folder import StarbucksVisitor as Eataly

--- a/example/import_test_project/init_file_folder/nested_folder/__init__.py
+++ b/example/import_test_project/init_file_folder/nested_folder/__init__.py
@@ -1,0 +1,1 @@
+from .starbucks import StarbucksVisitor

--- a/example/import_test_project/init_file_folder/nested_folder/starbucks.py
+++ b/example/import_test_project/init_file_folder/nested_folder/starbucks.py
@@ -1,0 +1,3 @@
+class StarbucksVisitor(object):
+  def __init__(self):
+    print ("Iced Mocha")

--- a/example/import_test_project/main.py
+++ b/example/import_test_project/main.py
@@ -1,4 +1,6 @@
 from A import B
 import A
+import D
 b = B('str')
 c = A.B('sss')
+d = D.a('hey')

--- a/example/import_test_project/multiple_files/A.py
+++ b/example/import_test_project/multiple_files/A.py
@@ -1,0 +1,2 @@
+def cosme(s):
+    return s + "aaa"

--- a/example/import_test_project/multiple_files/B.py
+++ b/example/import_test_project/multiple_files/B.py
@@ -1,0 +1,2 @@
+def foo(s):
+    return s + "bee"

--- a/example/import_test_project/multiple_files/C.py
+++ b/example/import_test_project/multiple_files/C.py
@@ -1,0 +1,2 @@
+def foo(s):
+    return s + "see"

--- a/example/import_test_project/multiple_files/D.py
+++ b/example/import_test_project/multiple_files/D.py
@@ -1,0 +1,2 @@
+def foo(s):
+    return s + "dee"

--- a/example/import_test_project/multiple_files_with_aliases.py
+++ b/example/import_test_project/multiple_files_with_aliases.py
@@ -1,0 +1,7 @@
+from .multiple_files import A, B as keens, C as per_se, D as duck_house
+
+
+a = A.cosme('tlayuda')
+b = keens.foo('mutton')
+c = per_se.foo('tasting')
+d = duck_house.foo('peking')

--- a/example/import_test_project/multiple_functions_with_aliases.py
+++ b/example/import_test_project/multiple_functions_with_aliases.py
@@ -1,0 +1,6 @@
+from .A import B as keens, C, D as duck_house
+
+
+a = keens('mutton')
+b = C('tasting')
+c = duck_house('peking')

--- a/example/import_test_project/no_all.py
+++ b/example/import_test_project/no_all.py
@@ -1,0 +1,6 @@
+from all_folder.no_all import *
+
+
+# _LemonGrass is not defined because it starts with _
+_LemonGrass()
+MangoYuzu()

--- a/example/import_test_project/other_dir/from_dot_dot.py
+++ b/example/import_test_project/other_dir/from_dot_dot.py
@@ -1,0 +1,4 @@
+from .. import A
+
+
+c = A.B('sss')

--- a/example/import_test_project/other_dir/relative_between_folders.py
+++ b/example/import_test_project/other_dir/relative_between_folders.py
@@ -1,0 +1,3 @@
+from ..foo.bar import H
+
+result = H('hey')

--- a/example/import_test_project/relative_from_directory.py
+++ b/example/import_test_project/relative_from_directory.py
@@ -1,0 +1,5 @@
+# Must be run as module via -m
+from .foo import bar
+
+
+bar.H('hey')

--- a/example/import_test_project/relative_level_1.py
+++ b/example/import_test_project/relative_level_1.py
@@ -1,0 +1,4 @@
+from .A import B
+import A
+b = B('str')
+c = A.B('sss')

--- a/example/import_test_project/relative_level_2.py
+++ b/example/import_test_project/relative_level_2.py
@@ -1,0 +1,4 @@
+from ..A import B
+import A
+b = B('str')
+c = A.B('sss')

--- a/example/nested_functions_code/nested_function_calls.py
+++ b/example/nested_functions_code/nested_function_calls.py
@@ -1,0 +1,1 @@
+abc = print(foo('bar'))

--- a/example/vulnerable_code/inter_command_injection.py
+++ b/example/vulnerable_code/inter_command_injection.py
@@ -1,6 +1,7 @@
 import subprocess
 from flask import Flask, render_template, request
 
+
 app = Flask(__name__)
 
 @app.route('/')
@@ -10,12 +11,14 @@ def index():
 
     return render_template('command_injection.html', menu=menu)
 
+def shell_the_arg(arg):
+    subprocess.call(arg, shell=True)
+
 @app.route('/menu', methods=['POST'])
 def menu():
     param = request.form['suggestion']
-    command = 'echo ' + param + ' >> ' + 'menu.txt'
 
-    subprocess.call(command, shell=True)
+    shell_the_arg('echo ' + param + ' >> ' + 'menu.txt')
 
     with open('menu.txt','r') as f:
         menu = f.read()

--- a/example/vulnerable_code/inter_command_injection_2.py
+++ b/example/vulnerable_code/inter_command_injection_2.py
@@ -1,6 +1,7 @@
 import subprocess
 from flask import Flask, render_template, request
 
+
 app = Flask(__name__)
 
 @app.route('/')
@@ -10,11 +11,14 @@ def index():
 
     return render_template('command_injection.html', menu=menu)
 
+def return_the_arg(foo):
+    return foo
+
 @app.route('/menu', methods=['POST'])
 def menu():
     param = request.form['suggestion']
-    command = 'echo ' + param + ' >> ' + 'menu.txt'
 
+    command = return_the_arg('echo ' + param + ' >> ' + 'menu.txt')
     subprocess.call(command, shell=True)
 
     with open('menu.txt','r') as f:

--- a/example/vulnerable_code_across_files/absolute_from_file_command_injection.py
+++ b/example/vulnerable_code_across_files/absolute_from_file_command_injection.py
@@ -1,0 +1,20 @@
+from flask import Flask, render_template, request
+
+from other_file import shell_the_arg
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    shell_the_arg('echo ' + param + ' >> ' + 'menu.txt')
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/absolute_from_file_command_injection_2.py
+++ b/example/vulnerable_code_across_files/absolute_from_file_command_injection_2.py
@@ -1,0 +1,22 @@
+import subprocess
+from flask import Flask, render_template, request
+
+from other_file import return_the_arg
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    command = return_the_arg('echo ' + param + ' >> ' + 'menu.txt')
+    subprocess.call(command, shell=True)
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/absolute_from_file_does_not_exist.py
+++ b/example/vulnerable_code_across_files/absolute_from_file_does_not_exist.py
@@ -1,0 +1,22 @@
+import subprocess
+from flask import Flask, render_template, request
+
+from other_file import does_not_exist
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    command = does_not_exist('echo ' + param + ' >> ' + 'menu.txt')
+    subprocess.call(command, shell=True)
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/import_file_command_injection.py
+++ b/example/vulnerable_code_across_files/import_file_command_injection.py
@@ -1,0 +1,20 @@
+from flask import Flask, render_template, request
+
+import other_file
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    other_file.shell_the_arg('echo ' + param + ' >> ' + 'menu.txt')
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/import_file_command_injection_2.py
+++ b/example/vulnerable_code_across_files/import_file_command_injection_2.py
@@ -1,0 +1,22 @@
+import subprocess
+from flask import Flask, render_template, request
+
+import other_file
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    command = other_file.return_the_arg('echo ' + param + ' >> ' + 'menu.txt')
+    subprocess.call(command, shell=True)
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/import_file_does_not_exist.py
+++ b/example/vulnerable_code_across_files/import_file_does_not_exist.py
@@ -1,0 +1,22 @@
+import subprocess
+from flask import Flask, render_template, request
+
+import other_file
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    command = other_file.does_not_exist('echo ' + param + ' >> ' + 'menu.txt')
+    subprocess.call(command, shell=True)
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/no_false_positive_absolute_from_file_command_injection_3.py
+++ b/example/vulnerable_code_across_files/no_false_positive_absolute_from_file_command_injection_3.py
@@ -1,0 +1,22 @@
+import subprocess
+from flask import Flask, render_template, request
+
+from other_file import return_constant_string
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    command = return_constant_string('echo ' + param + ' >> ' + 'menu.txt')
+    subprocess.call(command, shell=True)
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/no_false_positive_import_file_command_injection_3.py
+++ b/example/vulnerable_code_across_files/no_false_positive_import_file_command_injection_3.py
@@ -1,0 +1,22 @@
+import subprocess
+from flask import Flask, render_template, request
+
+import other_file
+
+
+app = Flask(__name__)
+
+@app.route('/menu', methods=['POST'])
+def menu():
+    param = request.form['suggestion']
+
+    command = other_file.return_constant_string('echo ' + param + ' >> ' + 'menu.txt')
+    subprocess.call(command, shell=True)
+
+    with open('menu.txt','r') as f:
+        menu = f.read()
+
+    return render_template('command_injection.html', menu=menu)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/example/vulnerable_code_across_files/other_file.py
+++ b/example/vulnerable_code_across_files/other_file.py
@@ -1,0 +1,12 @@
+import subprocess
+
+def return_constant_string(easy_to_find_in_logs):
+    no_vuln = "This is not a vuln"
+    return no_vuln
+
+def return_the_arg(easy_to_find_in_logs):
+    hehe = 'bar' + easy_to_find_in_logs
+    return hehe
+
+def shell_the_arg(easy_to_find_in_logs):
+    subprocess.call(easy_to_find_in_logs, shell=True)

--- a/func_counter.py
+++ b/func_counter.py
@@ -2,8 +2,8 @@
  to get an estimate og how big the CFG should be"""
 import ast
 
-from pyt.cfg import get_call_names_as_string, generate_ast
-from pyt.project_handler import get_python_modules
+from pyt.cfg import generate_ast, get_call_names_as_string
+from pyt.project_handler import get_modules
 
 
 function_calls = list()
@@ -34,7 +34,7 @@ class Counter(ast.NodeVisitor):
 
 
 if __name__ == '__main__':
-    module_paths = (m[1] for m in get_python_modules('../flaskbb/flaskbb'))
+    module_paths = (m[1] for m in get_modules('../flaskbb/flaskbb'))
     for p in module_paths:
         print(p)
         t = generate_ast(p)

--- a/pydocstyle.py
+++ b/pydocstyle.py
@@ -1,7 +1,7 @@
+import os
 import re
 import subprocess
 import sys
-import os
 
 
 os.chdir(os.path.join('pyt'))

--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -16,7 +16,7 @@ from .interprocedural_cfg import interprocedural
 from .intraprocedural_cfg import intraprocedural
 from .lattice import print_lattice
 from .liveness import LivenessAnalysis
-from .project_handler import get_directory_modules, get_python_modules
+from .project_handler import get_directory_modules, get_modules
 from .reaching_definitions import ReachingDefinitionsAnalysis
 from .reaching_definitions_taint import ReachingDefinitionsTaintAnalysis
 from .repo_runner import get_repos
@@ -143,7 +143,7 @@ search_parser.add_argument('-sd', '--start-date',
 
 def analyse_repo(github_repo, analysis_type):
     cfg_list = list()
-    project_modules = get_python_modules(os.path.dirname(github_repo.path))
+    project_modules = get_modules(os.path.dirname(github_repo.path))
     intraprocedural(project_modules, cfg_list)
     initialize_constraint_table(cfg_list)
     analyse(cfg_list, analysis_type=analysis_type)
@@ -196,7 +196,7 @@ if __name__ == '__main__':
         directory = os.path.normpath(args.project_root)
     else:
         directory = os.path.dirname(path)
-    project_modules = get_python_modules(directory)
+    project_modules = get_modules(directory)
     local_modules = get_directory_modules(directory)
 
     tree = generate_ast(path)

--- a/pyt/ast_helper.py
+++ b/pyt/ast_helper.py
@@ -73,9 +73,9 @@ def get_call_names(node):
     return reversed(get_call_names_helper(node, result))
 
 
-class Arguments(object):
+class Arguments():
     """Represents arguments of a function."""
-    
+
     def __init__(self, args):
         """Create an Argument container class.
 

--- a/pyt/base_cfg.py
+++ b/pyt/base_cfg.py
@@ -31,13 +31,12 @@ class Node():
             label (str): The label of the node, describing its expression.
             line_number(Optional[int]): The line of the expression of the Node.
         """
-        self.ingoing = list()
-        self.outgoing = list()
-
         self.label = label
         self.ast_node = ast_node
         self.line_number = line_number
         self.path = path
+        self.ingoing = list()
+        self.outgoing = list()
 
     def connect(self, successor):
         """Connect this node to its successor node by
@@ -56,7 +55,8 @@ class Node():
 
     def __str__(self):
         """Print the label of the node."""
-        return ' '.join(('Label: ', self.label))
+        return ''.join((' Label: ', self.label))
+
 
     def __repr__(self):
         """Print a representation of the node."""
@@ -90,7 +90,7 @@ class FunctionNode(Node):
     def __init__(self, ast_node):
         """Create a function node.
 
-        This node is a dummy node representing a function definition
+        This node is a dummy node representing a function definition.
         """
         super().__init__(self.__class__.__name__, ast_node)
 
@@ -162,7 +162,7 @@ class ReturnNode(AssignmentNode, ConnectToExitNode):
 
         Args:
             label (str): The label of the node, describing the expression it represents.
-            restore_nodes(list[Node]): List of nodes that where restored in the function call.
+            restore_nodes(list[Node]): List of nodes that were restored in the function call.
             right_hand_side_variables(list[str]): A list of variables on the right hand side.
             line_number(Optional[int]): The line of the expression the Node represents.
         """
@@ -252,6 +252,7 @@ class Visitor(ast.NodeVisitor):
     def connect_nodes(self, nodes):
         """Connect the nodes in a list linearly."""
         for n, next_node in zip(nodes, nodes[1:]):
+
             if isinstance(n, ControlFlowNode):  # case for if
                 self.connect_control_flow_node(n, next_node)
             elif isinstance(next_node, ControlFlowNode):  # case for if
@@ -273,7 +274,7 @@ class Visitor(ast.NodeVisitor):
     def stmt_star_handler(self, stmts):
         """Handle stmt* expressions in an AST node.
 
-        Links all statements together in a list of statements, accounting for statements with multiple last nodes
+        Links all statements together in a list of statements, accounting for statements with multiple last nodes.
         """
         cfg_statements = list()
         break_nodes = list()
@@ -286,7 +287,7 @@ class Visitor(ast.NodeVisitor):
             elif isinstance(node, BreakNode):
                 break_nodes.append(node)
 
-            if self.node_to_connect(node):
+            if self.node_to_connect(node) and node:
                 cfg_statements.append(node)
 
         self.connect_nodes(cfg_statements)
@@ -495,7 +496,6 @@ class Visitor(ast.NodeVisitor):
             return self.assign_multi_target(node, rhs_visitor.result)
         else:
             if isinstance(node.value, ast.Call):   #  x = call()
-
                 label = LabelVisitor()
                 label.visit(node.targets[0])
                 return self.assignment_call_node(label.result, node)
@@ -603,7 +603,6 @@ class Visitor(ast.NodeVisitor):
         label = LabelVisitor()
         label.visit(node)
         builtin_call = Node(label.result, node, line_number=node.lineno, path=self.filenames[-1])
-
         if not self.undecided:
             self.nodes.append(builtin_call)
         self.undecided = False

--- a/pyt/base_cfg.py
+++ b/pyt/base_cfg.py
@@ -252,7 +252,6 @@ class Visitor(ast.NodeVisitor):
     def connect_nodes(self, nodes):
         """Connect the nodes in a list linearly."""
         for n, next_node in zip(nodes, nodes[1:]):
-
             if isinstance(n, ControlFlowNode):  # case for if
                 self.connect_control_flow_node(n, next_node)
             elif isinstance(next_node, ControlFlowNode):  # case for if
@@ -602,10 +601,12 @@ class Visitor(ast.NodeVisitor):
     def add_builtin(self, node):
         label = LabelVisitor()
         label.visit(node)
+
         builtin_call = Node(label.result, node, line_number=node.lineno, path=self.filenames[-1])
         if not self.undecided:
             self.nodes.append(builtin_call)
         self.undecided = False
+
         return builtin_call
 
     def visit_Name(self, node):

--- a/pyt/cfg.py
+++ b/pyt/cfg.py
@@ -7,7 +7,6 @@ standard library.
 """
 
 import ast
-import logging
 from collections import namedtuple
 
 from .ast_helper import Arguments, generate_ast, get_call_names_as_string
@@ -54,11 +53,11 @@ class Visitor(ast.NodeVisitor):
         self.function_names.append(node.name)
         self.function_return_stack.append(node.name)
 
-        entry_node = self.append_node(EntryExitNode("Entry module"))
+        entry_node = self.append_node(EntryOrExitNode("Entry module"))
 
         module_statements = self.stmt_star_handler(node.body)
         if isinstance(module_statements, IgnoredNode):
-            exit_node = self.append_node(EntryExitNode("Exit module"))
+            exit_node = self.append_node(EntryOrExitNode("Exit module"))
             entry_node.connect(exit_node)
             return
 
@@ -66,7 +65,7 @@ class Visitor(ast.NodeVisitor):
         if CALL_IDENTIFIER not in first_node.label:
             entry_node.connect(first_node)
 
-        exit_node = self.append_node(EntryExitNode("Exit module"))
+        exit_node = self.append_node(EntryOrExitNode("Exit module"))
 
         last_nodes = module_statements.last_statements
         exit_node.connect_predecessors(last_nodes)

--- a/pyt/interprocedural_cfg.py
+++ b/pyt/interprocedural_cfg.py
@@ -7,7 +7,7 @@ from .base_cfg import (
     CALL_IDENTIFIER,
     CFG,
     ConnectToExitNode,
-    EntryExitNode,
+    EntryOrExitNode,
     IgnoredNode,
     Node,
     RestoreNode,
@@ -31,15 +31,15 @@ class InterproceduralVisitor(Visitor):
     def __init__(self, node, project_modules, local_modules,
                  filename, module_definitions=None):
         """Create an empty CFG."""
+        self.project_modules = project_modules
+        self.local_modules = local_modules
+        self.filenames = [filename]
         self.nodes = list()
         self.function_index = 0
         self.undecided = False
-        self.project_modules = project_modules
-        self.local_modules = local_modules
         self.function_names = list()
         self.function_return_stack = list()
         self.module_definitions_stack = list()
-        self.filenames = [filename]
 
         if module_definitions:
             self.init_function_cfg(node, module_definitions)
@@ -49,7 +49,7 @@ class InterproceduralVisitor(Visitor):
     def init_cfg(self, node):
         self.module_definitions_stack.append(ModuleDefinitions())
 
-        entry_node = self.append_node(EntryExitNode("Entry module"))
+        entry_node = self.append_node(EntryOrExitNode("Entry module"))
 
         module_statements = self.visit(node)
 
@@ -63,12 +63,12 @@ class InterproceduralVisitor(Visitor):
             if CALL_IDENTIFIER not in first_node.label:
                 entry_node.connect(first_node)
 
-            exit_node = self.append_node(EntryExitNode("Exit module"))
+            exit_node = self.append_node(EntryOrExitNode("Exit module"))
 
             last_nodes = module_statements.last_statements
             exit_node.connect_predecessors(last_nodes)
         else:
-            exit_node = self.append_node(EntryExitNode("Exit module"))
+            exit_node = self.append_node(EntryOrExitNode("Exit module"))
             entry_node.connect(exit_node)
 
     def init_function_cfg(self, node, module_definitions):
@@ -77,7 +77,7 @@ class InterproceduralVisitor(Visitor):
         self.function_names.append(node.name)
         self.function_return_stack.append(node.name)
 
-        entry_node = self.append_node(EntryExitNode("Entry module"))
+        entry_node = self.append_node(EntryOrExitNode("Entry module"))
 
         module_statements = self.stmt_star_handler(node.body)
 
@@ -86,7 +86,7 @@ class InterproceduralVisitor(Visitor):
         if CALL_IDENTIFIER not in first_node.label:
             entry_node.connect(first_node)
 
-        exit_node = self.append_node(EntryExitNode("Exit module"))
+        exit_node = self.append_node(EntryOrExitNode("Exit module"))
 
         last_nodes = module_statements.last_statements
         exit_node.connect_predecessors(last_nodes)
@@ -326,14 +326,14 @@ class InterproceduralVisitor(Visitor):
     def get_function_nodes(self, definition):
         length = len(self.nodes)
         previous_node = self.nodes[-1]
-        entry_node = self.append_node(EntryExitNode("Entry " +
+        entry_node = self.append_node(EntryOrExitNode("Entry " +
                                                     definition.name))
         previous_node.connect(entry_node)
         function_body_connect_statements = self.stmt_star_handler(definition.node.body)
 
         entry_node.connect(function_body_connect_statements.first_statement)
 
-        exit_node = self.append_node(EntryExitNode("Exit " + definition.name))
+        exit_node = self.append_node(EntryOrExitNode("Exit " + definition.name))
         exit_node.connect_predecessors(function_body_connect_statements.last_statements)
 
         self.return_connection_handler(self.nodes[length:], exit_node)
@@ -364,7 +364,7 @@ class InterproceduralVisitor(Visitor):
 
         previous_node = self.nodes[-1]
 
-        entry_node = self.append_node(EntryExitNode("Entry " + def_node.name))
+        entry_node = self.append_node(EntryOrExitNode("Entry " + def_node.name))
 
         previous_node.connect(entry_node)
 
@@ -372,7 +372,7 @@ class InterproceduralVisitor(Visitor):
 
         entry_node.connect(function_body_connect_statements.first_statement)
 
-        exit_node = self.append_node(EntryExitNode("Exit " + def_node.name))
+        exit_node = self.append_node(EntryOrExitNode("Exit " + def_node.name))
         exit_node.connect_predecessors(function_body_connect_statements.last_statements)
 
         return Node(label_visitor.result, call_node,
@@ -391,9 +391,9 @@ class InterproceduralVisitor(Visitor):
         module_definitions = ModuleDefinitions(local_names, module_name)
         self.module_definitions_stack.append(module_definitions)
 
-        self.append_node(EntryExitNode('Entry ' + module[0]))
+        self.append_node(EntryOrExitNode('Entry ' + module[0]))
         self.visit(tree)
-        exit_node = self.append_node(EntryExitNode('Exit ' + module[0]))
+        exit_node = self.append_node(EntryOrExitNode('Exit ' + module[0]))
 
         self.module_definitions_stack.pop()
         self.filenames.pop()

--- a/pyt/intraprocedural_cfg.py
+++ b/pyt/intraprocedural_cfg.py
@@ -4,7 +4,7 @@ from .ast_helper import Arguments, generate_ast
 from .base_cfg import (
     CALL_IDENTIFIER,
     CFG,
-    EntryExitNode,
+    EntryOrExitNode,
     IgnoredNode,
     Node,
     ReturnNode,
@@ -32,7 +32,7 @@ class IntraproceduralVisitor(Visitor):
             self.init_module_cfg(node)
 
     def init_module_cfg(self, node):
-        entry_node = self.append_node(EntryExitNode("Entry module"))
+        entry_node = self.append_node(EntryOrExitNode("Entry module"))
 
         module_statements = self.visit(node)
 
@@ -46,21 +46,21 @@ class IntraproceduralVisitor(Visitor):
             if CALL_IDENTIFIER not in first_node.label:
                 entry_node.connect(first_node)
 
-            exit_node = self.append_node(EntryExitNode("Exit module"))
+            exit_node = self.append_node(EntryOrExitNode("Exit module"))
 
             last_nodes = module_statements.last_statements
             exit_node.connect_predecessors(last_nodes)
         else:
-            exit_node = self.append_node(EntryExitNode("Exit module"))
+            exit_node = self.append_node(EntryOrExitNode("Exit module"))
             entry_node.connect(exit_node)
 
     def init_function_cfg(self, node):
 
-        entry_node = self.append_node(EntryExitNode("Entry module"))
+        entry_node = self.append_node(EntryOrExitNode("Entry module"))
 
         module_statements = self.stmt_star_handler(node.body)
         if isinstance(module_statements, IgnoredNode):
-            exit_node = self.append_node(EntryExitNode("Exit module"))
+            exit_node = self.append_node(EntryOrExitNode("Exit module"))
             entry_node.connect(exit_node)
             return
 
@@ -68,7 +68,7 @@ class IntraproceduralVisitor(Visitor):
         if CALL_IDENTIFIER not in first_node.label:
             entry_node.connect(first_node)
 
-        exit_node = self.append_node(EntryExitNode("Exit module"))
+        exit_node = self.append_node(EntryOrExitNode("Exit module"))
 
         last_nodes = module_statements.last_statements
         exit_node.connect_predecessors(last_nodes)

--- a/pyt/liveness.py
+++ b/pyt/liveness.py
@@ -1,6 +1,6 @@
 import ast
 
-from .base_cfg import AssignmentNode, EntryExitNode
+from .base_cfg import AssignmentNode, EntryOrExitNode
 from .analysis_base import AnalysisBase
 from .lattice import Lattice
 from .constraint_table import constraint_table, constraint_join
@@ -84,7 +84,7 @@ class LivenessAnalysis(AnalysisBase):
 
     def fixpointmethod(self, cfg_node):
 
-        if isinstance(cfg_node, EntryExitNode) and 'Exit' in cfg_node.label:
+        if isinstance(cfg_node, EntryOrExitNode) and 'Exit' in cfg_node.label:
             constraint_table[cfg_node] = 0
         elif isinstance(cfg_node, AssignmentNode):
             JOIN = self.join(cfg_node)

--- a/pyt/module_definitions.py
+++ b/pyt/module_definitions.py
@@ -32,7 +32,6 @@ class ModuleDefinition():
 
 class LocalModuleDefinition(ModuleDefinition):
     """A local definition."""
-
     pass
 
 
@@ -77,8 +76,8 @@ class ModuleDefinitions():
         for definition in self.definitions:
             if definition.name == name:
                 return definition
-            
-    def set_defintion_node(self, node, name):
+
+    def set_definition_node(self, node, name):
         """Set definition by name."""
         definition = self.get_definition(name)
         if definition:
@@ -88,7 +87,7 @@ class ModuleDefinitions():
         module = 'NoModuleName'
         if self.module_name:
             module = self.module_name
-            
+
         return 'Definitions: ' + ' '.join([str(definition) for definition in self.definitions]) + '\nmodule_name: ' + module + '\n'
 
-            
+

--- a/pyt/project_handler.py
+++ b/pyt/project_handler.py
@@ -1,44 +1,52 @@
 """Generates a list of CFGs from a path.
 
 The module finds all python modules and generates an ast for them.
-Then
 """
 import ast
 import os
 
 
-def is_python_module(path):
+def is_python_file(path):
     if os.path.splitext(path)[1] == '.py':
         return True
     return False
 
 local_modules = list()
 def get_directory_modules(directory, flush_local_modules=False):
+    """Return a list containing tuples of
+    e.g. ('__init__', 'example/import_test_project/__init__.py')
+    """
     if local_modules and os.path.dirname(local_modules[0][1]) == directory:
         return local_modules
 
     if flush_local_modules:
         del local_modules[:]
 
+
     if not os.path.isdir(directory):
+        # example/import_test_project/A.py -> example/import_test_project
         directory = os.path.dirname(directory)
 
     if directory == '':
         return local_modules
 
     for path in os.listdir(directory):
-        if is_python_module(path):
+        if is_python_file(path):
+            # A.py -> A
             module_name = os.path.splitext(path)[0]
             local_modules.append((module_name, os.path.join(directory, path)))
 
     return local_modules
 
 def get_python_modules(path):
+    """Return a list containing tuples of
+    e.g. ('test_project.utils', 'example/test_project/utils.py')
+    """
     module_root = os.path.split(path)[1]
     modules = list()
     for root, directories, filenames in os.walk(path):
         for filename in filenames:
-            if is_python_module(filename):
+            if is_python_file(filename):
                 directory = os.path.dirname(os.path.realpath(os.path.join(root, filename))).split(module_root)[-1].replace(os.sep, '.')
                 directory = directory.replace('.', '', 1)
                 if directory:
@@ -58,6 +66,6 @@ def get_project_module_names(path):
 def is_directory(path):
     if os.path.isdir(path):
         return True
-    elif is_python_module(path):
+    elif is_python_file(path):
         return False
     raise Exception(path, ' has to be a python module or a directory.')

--- a/pyt/vulnerability_log.py
+++ b/pyt/vulnerability_log.py
@@ -4,7 +4,7 @@ This log is able to give precise information about where a vulnerability is loca
 The log is printed to the standard output.
 """
 
-class VulnerabilityLog(object):
+class VulnerabilityLog():
     """Log that consists of vulnerabilities."""
 
     def __init__(self):
@@ -38,7 +38,7 @@ class Reassigned():
         return secondary
 
 
-class Vulnerability(object):
+class Vulnerability():
     """Vulnerability containing the source and the sources trigger word, the sink and the sinks trigger word."""
 
     def __init__(self, source, source_trigger_word, sink, sink_trigger_word, secondary_nodes):

--- a/pyt/vulnerability_log.py
+++ b/pyt/vulnerability_log.py
@@ -1,7 +1,7 @@
 """This module contains a vulnerability log.
 
 This log is able to give precise information about where a vulnerability is located.
-The log is printed to the standard output.
+The log is printed to standard output.
 """
 
 class VulnerabilityLog():

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 long_description = """"""
 

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -10,10 +10,10 @@ class BaseTestCase(unittest.TestCase):
     """A base class that has helper methods for testing PyT."""
 
     def assertInCfg(self, connections):
-        ''' Assert that all connections in the connections list exists in the cfg,
+        """ Assert that all connections in the connections list exists in the cfg,
         as well as all connections not in the list do not exist
 
-        connections is a list of tuples where the node at index 0 of the tuple has to be in the new_constraintset of the node a index 1 of the tuple'''
+        connections is a list of tuples where the node at index 0 of the tuple has to be in the new_constraintset of the node a index 1 of the tuple"""
         for connection in connections:
             self.assertIn(self.cfg.nodes[connection[0]], self.cfg.nodes[connection[1]].outgoing, str(connection) + " expected to be connected")
             self.assertIn(self.cfg.nodes[connection[1]], self.cfg.nodes[connection[0]].ingoing, str(connection) + " expected to be connected")
@@ -27,9 +27,9 @@ class BaseTestCase(unittest.TestCase):
                     self.assertNotIn(self.cfg.nodes[sets], self.cfg.nodes[element].ingoing, "(%s <- %s)" % (sets, element)  +  " expected to be disconnected")
 
     def assertConnected(self, node, successor):
-        '''Asserts that a node is connected to its successor.
+        """Asserts that a node is connected to its successor.
         This means that node has successor in its outgoing and
-        successor has node in its ingoing.'''
+        successor has node in its ingoing."""
 
         self.assertIn(successor, node.outgoing,
                        '\n%s was NOT found in the outgoing list of %s containing: ' % (successor.label, node.label) + '[' + ', '.join([x.label for x in node.outgoing]) + ']')
@@ -38,9 +38,9 @@ class BaseTestCase(unittest.TestCase):
                        '\n%s was NOT found in the ingoing list of %s containing: ' % (node.label, successor.label) + '[' + ', '.join([x.label for x in successor.ingoing]) + ']')
 
     def assertNotConnected(self, node, successor):
-        '''Asserts that a node is not connected to its successor.
+        """Asserts that a node is not connected to its successor.
         This means that node does not the successor in its outgoing and
-        successor does not have the node in its ingoing.'''
+        successor does not have the node in its ingoing."""
 
         self.assertNotIn(successor, node.outgoing,
                        '\n%s was mistakenly found in the outgoing list of %s containing: ' % (successor.label, node.label) + '[' + ', '.join([x.label for x in node.outgoing]) + ']')
@@ -52,8 +52,8 @@ class BaseTestCase(unittest.TestCase):
         self.assertEqual(node.line_number, line_number)
 
     def cfg_list_to_dict(self, list):
-        '''This method converts the CFG list to a dict, making it easier to find nodes to test.
-        This method assumes that no nodes in the code have the same label'''
+        """This method converts the CFG list to a dict, making it easier to find nodes to test.
+        This method assumes that no nodes in the code have the same label"""
         return {x.label: x for x in list}
 
     def assert_length(self, _list, *, expected_length):

--- a/tests/cfg_test.py
+++ b/tests/cfg_test.py
@@ -1,5 +1,5 @@
 from .base_test_case import BaseTestCase
-from pyt.base_cfg import Node, EntryExitNode
+from pyt.base_cfg import EntryOrExitNode, Node
 from pyt.project_handler import get_python_modules
 
 
@@ -38,8 +38,8 @@ class CFGGeneralTest(BaseTestCase):
 
         self.assertInCfg([(1,0),(2,1)])
 
-        self.assertEqual(type(self.cfg.nodes[start_node]), EntryExitNode)
-        self.assertEqual(type(self.cfg.nodes[exit_node]), EntryExitNode)
+        self.assertEqual(type(self.cfg.nodes[start_node]), EntryOrExitNode)
+        self.assertEqual(type(self.cfg.nodes[exit_node]), EntryOrExitNode)
 
     def test_start_and_exit_nodes_line_numbers(self):
         self.cfg_create_from_file('example/example_inputs/simple.py')

--- a/tests/cfg_test.py
+++ b/tests/cfg_test.py
@@ -1,6 +1,6 @@
 from .base_test_case import BaseTestCase
 from pyt.base_cfg import EntryOrExitNode, Node
-from pyt.project_handler import get_python_modules
+# from pyt.project_handler import get_modules
 
 
 class CFGGeneralTest(BaseTestCase):
@@ -707,9 +707,9 @@ class CFGFunctionNodeTest(BaseTestCase):
     def test_function_line_numbers_2(self):
         path = 'example/example_inputs/simple_function_with_return.py'
         self.cfg_create_from_file(path)
-#        self.cfg = CFG(get_python_modules(path))
- #       tree = generate_ast(path)
-  #      self.cfg.create(tree)
+        # self.cfg = CFG(get_modules(path))
+        # tree = generate_ast(path)
+        # self.cfg.create(tree)
 
         assignment_with_function = self.cfg.nodes[1]
 

--- a/tests/flask_adaptor_test.py
+++ b/tests/flask_adaptor_test.py
@@ -10,7 +10,12 @@ class FlaskEngineTest(BaseTestCase):
         cfg_list = [self.cfg]
 
         flask = FlaskAdaptor(cfg_list, list(), list())
+        funcs = flask.get_func_nodes()
 
-        #self.assertEqual(len(flask_functions), 1)
-
-        #self.assertEqual(flask_functions[0], 'flask_function')
+        i = 0
+        for func in funcs:
+            if flask.is_flask_route_function(func.node):
+                self.assertEqual(func.node.name, 'flask_function')
+                i = i + 1
+        # So it is supposed to be 1, because foo is not an app.route
+        self.assertEqual(i, 1)

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -3,33 +3,98 @@ import os
 
 from .base_test_case import BaseTestCase
 from pyt.ast_helper import get_call_names_as_string
-from pyt.project_handler import get_directory_modules, get_python_modules
+from pyt.project_handler import get_directory_modules, get_modules_and_packages
 
 
 class ImportTest(BaseTestCase):
     def test_import(self):
-        path = os.path.normpath('example/import_test_project/main.py')
+        path = os.path.normpath('example/import_test_project/import.py')
 
-        project_modules = get_python_modules(os.path.dirname(path))
+        project_modules = get_modules_and_packages(os.path.dirname(path))
         local_modules = get_directory_modules(os.path.dirname(path))
 
         self.cfg_create_from_file(path, project_modules, local_modules)
 
-        EXPECTED = ['Entry module',
-                    'Module Entry A',
-                    'Module Exit A',
-                    'Module Entry A',
-                    'Module Exit A',
-                    'temp_1_s = \'str\'',
-                    's = temp_1_s',
-                    'Function Entry B',
-                    'ret_B = s',
-                    'Exit B',
-                    '¤call_1 = ret_B',
-                    'b = ¤call_1',
-                    'c = A.B(\'sss\')',
-                    'd = D.a(\'hey\')',
-                    'Exit module']
+        EXPECTED = ["Entry module",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "temp_1_s = 'str'",
+                    "s = temp_1_s",
+                    "Function Entry B",
+                    "ret_B = s",
+                    "Exit B",
+                    "¤call_1 = ret_B",
+                    "b = ¤call_1",
+                    "save_2_b = b",
+                    "temp_2_s = 'sss'",
+                    "s = temp_2_s",
+                    "Function Entry A.B",
+                    "ret_A.B = s",
+                    "Exit A.B",
+                    "b = save_2_b",
+                    "¤call_2 = ret_A.B",
+                    "c = ¤call_2",
+                    "Exit module"]
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_import_as(self):
+        path = os.path.normpath('example/import_test_project/import_as.py')
+
+        project_modules = get_modules_and_packages(os.path.dirname(path))
+        local_modules = get_directory_modules(os.path.dirname(path))
+
+        self.cfg_create_from_file(path, project_modules, local_modules)
+
+        EXPECTED = ["Entry module",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "temp_1_s = 'str'",
+                    "s = temp_1_s",
+                    "Function Entry B",
+                    "ret_B = s",
+                    "Exit B",
+                    "¤call_1 = ret_B",
+                    "b = ¤call_1",
+                    "save_2_b = b",
+                    "temp_2_s = 'sss'",
+                    "s = temp_2_s",
+                    "Function Entry A.B",
+                    "ret_foo.B = s",
+                    "Exit A.B",
+                    "b = save_2_b",
+                    "¤call_2 = ret_foo.B",
+                    "c = ¤call_2",
+                    "Exit module"]
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_from_directory(self):
+        file_path = os.path.normpath('example/import_test_project/from_directory.py')
+        project_path = os.path.normpath('example/import_test_project')
+
+        project_modules = get_modules_and_packages(project_path)
+        local_modules = get_directory_modules(project_path)
+
+        self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+
+        EXPECTED = ["Entry module",
+                    "Module Entry bar",
+                    "Module Exit bar",
+                    "temp_1_s = 'hey'",
+                    "s = temp_1_s",
+                    "Function Entry bar.H",
+                    "ret_bar.H = s + 'end'",
+                    "Exit bar.H",
+                    "¤call_1 = ret_bar.H",
+                    "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
             self.assertEqual(node.label, expected_label)
@@ -37,25 +102,33 @@ class ImportTest(BaseTestCase):
     def test_relative_level_1(self):
         path = os.path.normpath('example/import_test_project/relative_level_1.py')
 
-        project_modules = get_python_modules(os.path.dirname(path))
+        project_modules = get_modules_and_packages(os.path.dirname(path))
         local_modules = get_directory_modules(os.path.dirname(path))
 
         self.cfg_create_from_file(path, project_modules, local_modules)
 
-        EXPECTED = ['Entry module',
-                    'Module Entry A',
-                    'Module Exit A',
-                    'Module Entry A',
-                    'Module Exit A',
-                    'temp_1_s = \'str\'',
-                    's = temp_1_s',
-                    'Function Entry B',
-                    'ret_B = s',
-                    'Exit B',
-                    '¤call_1 = ret_B',
-                    'b = ¤call_1',
-                    'c = A.B(\'sss\')',
-                    'Exit module']
+        EXPECTED = ["Entry module",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "temp_1_s = 'str'",
+                    "s = temp_1_s",
+                    "Function Entry B",
+                    "ret_B = s",
+                    "Exit B",
+                    "¤call_1 = ret_B",
+                    "b = ¤call_1",
+                    "save_2_b = b",
+                    "temp_2_s = 'sss'",
+                    "s = temp_2_s",
+                    "Function Entry A.B",
+                    "ret_A.B = s",
+                    "Exit A.B",
+                    "b = save_2_b",
+                    "¤call_2 = ret_A.B",
+                    "c = ¤call_2",
+                    "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
             self.assertEqual(node.label, expected_label)
@@ -63,7 +136,7 @@ class ImportTest(BaseTestCase):
     def test_relative_level_2(self):
         path = os.path.normpath('example/import_test_project/relative_level_2.py')
 
-        project_modules = get_python_modules(os.path.dirname(path))
+        project_modules = get_modules_and_packages(os.path.dirname(path))
         local_modules = get_directory_modules(os.path.dirname(path))
 
         try:
@@ -74,27 +147,250 @@ class ImportTest(BaseTestCase):
 
     def test_relative_between_folders(self):
         file_path = os.path.normpath('example/import_test_project/other_dir/relative_between_folders.py')
-        project_path = os.path.normpath('example/import_test_project/h.py')
+        project_path = os.path.normpath('example/import_test_project')
 
-        project_modules = get_python_modules(os.path.dirname(project_path))
-        local_modules = get_directory_modules(os.path.dirname(project_path))
+        project_modules = get_modules_and_packages(project_path)
+        local_modules = get_directory_modules(project_path)
+
+        self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+        EXPECTED = ["Entry module",
+                    "Module Entry foo.bar",
+                    "Module Exit foo.bar",
+                    "temp_1_s = 'hey'",
+                    "s = temp_1_s",
+                    "Function Entry H",
+                    "ret_H = s + 'end'",
+                    "Exit H",
+                    "¤call_1 = ret_H",
+                    "result = ¤call_1",
+                    "Exit module"]
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_relative_from_directory(self):
+        file_path = os.path.normpath('example/import_test_project/relative_from_directory.py')
+        project_path = os.path.normpath('example/import_test_project')
+
+        project_modules = get_modules_and_packages(project_path)
+        local_modules = get_directory_modules(project_path)
+
+        self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+        EXPECTED = ["Entry module",
+                    "Module Entry bar",
+                    "Module Exit bar",
+                    "temp_1_s = 'hey'",
+                    "s = temp_1_s",
+                    "Function Entry bar.H",
+                    "ret_bar.H = s + 'end'",
+                    "Exit bar.H",
+                    "¤call_1 = ret_bar.H",
+                    "Exit module"]
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_from_dot(self):
+        file_path = os.path.normpath('example/import_test_project/from_dot.py')
+        project_path = os.path.normpath('example/import_test_project')
+
+        project_modules = get_modules_and_packages(project_path)
+        local_modules = get_directory_modules(project_path)
 
         self.cfg_create_from_file(file_path, project_modules, local_modules)
 
         EXPECTED = ['Entry module',
-                    'Module Entry foo.bar',
-                    'Module Exit foo.bar',
-                    'temp_1_s = \'hey\'',
+                    'Module Entry A',
+                    'Module Exit A',
+                    'temp_1_s = \'sss\'',
                     's = temp_1_s',
-                    'Function Entry H',
-                    'ret_H = s',
-                    'Exit H',
-                    '¤call_1 = ret_H',
-                    'result = ¤call_1',
+                    'Function Entry A.B',
+                    'ret_A.B = s',
+                    'Exit A.B',
+                    '¤call_1 = ret_A.B',
+                    'c = ¤call_1',
                     'Exit module']
+
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
             self.assertEqual(node.label, expected_label)
+
+    def test_from_dot_dot(self):
+        file_path = os.path.normpath('example/import_test_project/other_dir/from_dot_dot.py')
+        project_path = os.path.normpath('example/import_test_project')
+
+        project_modules = get_modules_and_packages(project_path)
+        local_modules = get_directory_modules(project_path)
+
+        self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+        EXPECTED = ['Entry module',
+                    'Module Entry A',
+                    'Module Exit A',
+                    'temp_1_s = \'sss\'',
+                    's = temp_1_s',
+                    'Function Entry A.B',
+                    'ret_A.B = s',
+                    'Exit A.B',
+                    '¤call_1 = ret_A.B',
+                    'c = ¤call_1',
+                    'Exit module']
+
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_multiple_files_with_aliases(self):
+        file_path = os.path.normpath('example/import_test_project/multiple_files_with_aliases.py')
+        project_path = os.path.normpath('example/import_test_project')
+
+        project_modules = get_modules_and_packages(project_path)
+        local_modules = get_directory_modules(project_path)
+
+        self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+        EXPECTED = ["Entry module",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "Module Entry B",
+                    "Module Exit B",
+                    "Module Entry C",
+                    "Module Exit C",
+                    "Module Entry D",
+                    "Module Exit D",
+                    "temp_1_s = 'tlayuda'",
+                    "s = temp_1_s",
+                    "Function Entry A.cosme",
+                    "ret_A.cosme = s + 'aaa'",
+                    "Exit A.cosme",
+                    "¤call_1 = ret_A.cosme",
+                    "a = ¤call_1",
+                    "save_2_a = a",
+                    "temp_2_s = 'mutton'",
+                    "s = temp_2_s",
+                    "Function Entry B.foo",
+                    "ret_keens.foo = s + 'bee'",
+                    "Exit B.foo",
+                    "a = save_2_a",
+                    "¤call_2 = ret_keens.foo",
+                    "b = ¤call_2",
+                    "save_3_a = a",
+                    "save_3_b = b",
+                    "temp_3_s = 'tasting'",
+                    "s = temp_3_s",
+                    "Function Entry C.foo",
+                    "ret_per_se.foo = s + 'see'",
+                    "Exit C.foo",
+                    "a = save_3_a",
+                    "b = save_3_b",
+                    "¤call_3 = ret_per_se.foo",
+                    "c = ¤call_3",
+                    "save_4_a = a",
+                    "save_4_b = b",
+                    "save_4_c = c",
+                    "temp_4_s = 'peking'",
+                    "s = temp_4_s",
+                    "Function Entry D.foo",
+                    "ret_duck_house.foo = s + 'dee'",
+                    "Exit D.foo",
+                    "a = save_4_a",
+                    "b = save_4_b",
+                    "c = save_4_c",
+                    "¤call_4 = ret_duck_house.foo",
+                    "d = ¤call_4",
+                    "Exit module"]
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_multiple_functions_with_aliases(self):
+        file_path = os.path.normpath('example/import_test_project/multiple_functions_with_aliases.py')
+        project_path = os.path.normpath('example/import_test_project')
+
+        project_modules = get_modules_and_packages(project_path)
+        local_modules = get_directory_modules(project_path)
+
+        self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+        EXPECTED = ["Entry module",
+                    "Module Entry A",
+                    "Module Exit A",
+                    "temp_1_s = 'mutton'",
+                    "s = temp_1_s",
+                    "Function Entry B",
+                    "ret_keens = s",
+                    "Exit B",
+                    "¤call_1 = ret_keens",
+                    "a = ¤call_1",
+                    "save_2_a = a",
+                    "temp_2_s = 'tasting'",
+                    "s = temp_2_s",
+                    "Function Entry C",
+                    "ret_C = s + 'see'",
+                    "Exit C",
+                    "a = save_2_a",
+                    "¤call_2 = ret_C",
+                    "b = ¤call_2",
+                    "save_3_a = a",
+                    "save_3_b = b",
+                    "temp_3_s = 'peking'",
+                    "s = temp_3_s",
+                    "Function Entry D",
+                    "ret_duck_house = s + 'dee'",
+                    "Exit D",
+                    "a = save_3_a",
+                    "b = save_3_b",
+                    "¤call_3 = ret_duck_house",
+                    "c = ¤call_3",
+                    "Exit module"]
+
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    # def test_init(self):
+    #     file_path = os.path.normpath('example/import_test_project/init.py')
+    #     project_path = os.path.normpath('example/import_test_project')
+
+    #     project_modules = get_modules_and_packages(project_path)
+    #     local_modules = get_directory_modules(project_path)
+
+    #     self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+    #     EXPECTED = ['Not Yet']
+
+    #     for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+    #         self.assertEqual(node.label, expected_label)
+
+    # def test_all(self):
+    #     file_path = os.path.normpath('example/import_test_project/all.py')
+    #     project_path = os.path.normpath('example/import_test_project')
+
+    #     project_modules = get_modules_and_packages(project_path)
+    #     local_modules = get_directory_modules(project_path)
+
+    #     self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+    #     EXPECTED = ['Not Yet']
+
+    #     for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+    #         self.assertEqual(node.label, expected_label)
+
+    # def test_no_all(self):
+    #     file_path = os.path.normpath('example/import_test_project/no_all.py')
+    #     project_path = os.path.normpath('example/import_test_project')
+
+    #     project_modules = get_modules_and_packages(project_path)
+    #     local_modules = get_directory_modules(project_path)
+
+    #     self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+    #     EXPECTED = ['Not Yet']
+
+    #     for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+    #         self.assertEqual(node.label, expected_label)
 
     def test_get_call_names_single(self):
         m = ast.parse('hi(a)')
@@ -111,7 +407,6 @@ class ImportTest(BaseTestCase):
         result = get_call_names_as_string(call.func)
 
         self.assertEqual(result, 'defg.hi')
-
 
     def test_get_call_names_multi(self):
         m = ast.parse('abc.defg.hi(a)')

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -2,7 +2,7 @@ import ast
 import os
 
 from .base_test_case import BaseTestCase
-from pyt.base_cfg import get_call_names_as_string
+from pyt.ast_helper import get_call_names_as_string
 from pyt.project_handler import get_directory_modules, get_python_modules
 
 
@@ -15,9 +15,86 @@ class ImportTest(BaseTestCase):
 
         self.cfg_create_from_file(path, project_modules, local_modules)
 
-        cfg_list = [self.cfg]
+        EXPECTED = ['Entry module',
+                    'Module Entry A',
+                    'Module Exit A',
+                    'Module Entry A',
+                    'Module Exit A',
+                    'temp_1_s = \'str\'',
+                    's = temp_1_s',
+                    'Function Entry B',
+                    'ret_B = s',
+                    'Exit B',
+                    '¤call_1 = ret_B',
+                    'b = ¤call_1',
+                    'c = A.B(\'sss\')',
+                    'd = D.a(\'hey\')',
+                    'Exit module']
 
-        #adaptor_type = FlaskAdaptor(cfg_list)
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_relative_level_1(self):
+        path = os.path.normpath('example/import_test_project/relative_level_1.py')
+
+        project_modules = get_python_modules(os.path.dirname(path))
+        local_modules = get_directory_modules(os.path.dirname(path))
+
+        self.cfg_create_from_file(path, project_modules, local_modules)
+
+        EXPECTED = ['Entry module',
+                    'Module Entry A',
+                    'Module Exit A',
+                    'Module Entry A',
+                    'Module Exit A',
+                    'temp_1_s = \'str\'',
+                    's = temp_1_s',
+                    'Function Entry B',
+                    'ret_B = s',
+                    'Exit B',
+                    '¤call_1 = ret_B',
+                    'b = ¤call_1',
+                    'c = A.B(\'sss\')',
+                    'Exit module']
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
+
+    def test_relative_level_2(self):
+        path = os.path.normpath('example/import_test_project/relative_level_2.py')
+
+        project_modules = get_python_modules(os.path.dirname(path))
+        local_modules = get_directory_modules(os.path.dirname(path))
+
+        try:
+            self.cfg_create_from_file(path, project_modules, local_modules)
+        except Exception as e:
+            self.assertTrue("OSError('Input needs to be a file. Path: " in repr(e))
+            self.assertTrue("example/A.py" in repr(e))
+
+    def test_relative_between_folders(self):
+        file_path = os.path.normpath('example/import_test_project/other_dir/relative_between_folders.py')
+        project_path = os.path.normpath('example/import_test_project/h.py')
+
+        project_modules = get_python_modules(os.path.dirname(project_path))
+        local_modules = get_directory_modules(os.path.dirname(project_path))
+
+        self.cfg_create_from_file(file_path, project_modules, local_modules)
+
+        EXPECTED = ['Entry module',
+                    'Module Entry foo.bar',
+                    'Module Exit foo.bar',
+                    'temp_1_s = \'hey\'',
+                    's = temp_1_s',
+                    'Function Entry H',
+                    'ret_H = s',
+                    'Exit H',
+                    '¤call_1 = ret_H',
+                    'result = ¤call_1',
+                    'Exit module']
+
+        for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+            self.assertEqual(node.label, expected_label)
 
     def test_get_call_names_single(self):
         m = ast.parse('hi(a)')

--- a/tests/label_visitor_test.py
+++ b/tests/label_visitor_test.py
@@ -5,7 +5,7 @@ from pyt.label_visitor import LabelVisitor
 
 
 class LabelVisitorTestCase(unittest.TestCase):
-    '''Baseclass for LabelVisitor tests'''
+    """Baseclass for LabelVisitor tests"""
 
     def perform_labeling_on_expression(self, expr):
         obj = ast.parse(expr)

--- a/tests/nested_functions_test.py
+++ b/tests/nested_functions_test.py
@@ -1,0 +1,20 @@
+# import os.path
+
+# from .base_test_case import BaseTestCase
+# from pyt.project_handler import get_directory_modules, get_modules_and_packages
+
+
+# class NestedTest(BaseTestCase):
+    # def test_nested_function_calls(self):
+
+    #     path = os.path.normpath('example/nested_functions_code/nested_function_calls.py')
+
+    #     project_modules = get_modules_and_packages(os.path.dirname(path))
+    #     local_modules = get_directory_modules(os.path.dirname(path))
+
+    #     self.cfg_create_from_file(path, project_modules, local_modules)
+
+    #     EXPECTED = ['Not Yet']
+
+    #     for node, expected_label in zip(self.cfg.nodes, EXPECTED):
+    #         self.assertEqual(node.label, expected_label)

--- a/tests/project_handler_test.py
+++ b/tests/project_handler_test.py
@@ -2,18 +2,18 @@ import os
 import unittest
 from pprint import pprint
 
-from pyt.project_handler import get_python_modules, is_python_module
+from pyt.project_handler import get_python_modules, is_python_file
 
 
 class ProjectHandlerTest(unittest.TestCase):
     """Tests for the project handler."""
 
-    def test_is_python_module(self):
+    def test_is_python_file(self):
         python_module = './project_handler_test.py'
         not_python_module = '../.travis.yml'
 
-        self.assertEqual(is_python_module(python_module), True)
-        self.assertEqual(is_python_module(not_python_module), False)
+        self.assertEqual(is_python_file(python_module), True)
+        self.assertEqual(is_python_file(not_python_module), False)
 
     def test_get_python_modules(self):
         project_folder = os.path.normpath(os.path.join('example', 'test_project'))
@@ -22,13 +22,15 @@ class ProjectHandlerTest(unittest.TestCase):
         folder = 'folder'
         directory = 'directory'
 
+        # get_python_modules will return a list containing tuples of
+        # e.g. ('test_project.utils', 'example/test_project/utils.py')
         modules = get_python_modules(project_folder)
 
         app_path = os.path.join(project_folder, 'app.py')
         utils_path = os.path.join(project_folder,'utils.py')
         exceptions_path = os.path.join(project_folder, 'exceptions.py')
         some_path = os.path.join(project_folder, folder, 'some.py')
-        indhold_path = os.path.join(project_folder, folder, 'indhold.py')
+        indhold_path = os.path.join(project_folder, folder, directory, 'indhold.py')
 
         app_name = project_namespace + '.' + 'app'
         utils_name = project_namespace + '.' + 'utils'
@@ -40,10 +42,12 @@ class ProjectHandlerTest(unittest.TestCase):
         utils_tuple = (utils_name, utils_path)
         exceptions_tuple = (exceptions_name, exceptions_path)
         some_tuple = (some_name, some_path)
+        indhold_tuple = (indhold_name, indhold_path)
 
         self.assertIn(app_tuple, modules)
         self.assertIn(utils_tuple, modules)
         self.assertIn(exceptions_tuple, modules)
         self.assertIn(some_tuple, modules)
+        self.assertIn(indhold_tuple, modules)
 
         self.assertEqual(len(modules), 5)

--- a/tests/project_handler_test.py
+++ b/tests/project_handler_test.py
@@ -2,8 +2,11 @@ import os
 import unittest
 from pprint import pprint
 
-from pyt.project_handler import get_python_modules, is_python_file
-
+from pyt.project_handler import (
+    get_modules,
+    get_modules_and_packages,
+    is_python_file
+)
 
 class ProjectHandlerTest(unittest.TestCase):
     """Tests for the project handler."""
@@ -15,16 +18,14 @@ class ProjectHandlerTest(unittest.TestCase):
         self.assertEqual(is_python_file(python_module), True)
         self.assertEqual(is_python_file(not_python_module), False)
 
-    def test_get_python_modules(self):
+    def test_get_modules(self):
         project_folder = os.path.normpath(os.path.join('example', 'test_project'))
 
         project_namespace = 'test_project'
         folder = 'folder'
         directory = 'directory'
 
-        # get_python_modules will return a list containing tuples of
-        # e.g. ('test_project.utils', 'example/test_project/utils.py')
-        modules = get_python_modules(project_folder)
+        modules = get_modules(project_folder)
 
         app_path = os.path.join(project_folder, 'app.py')
         utils_path = os.path.join(project_folder,'utils.py')
@@ -32,6 +33,7 @@ class ProjectHandlerTest(unittest.TestCase):
         some_path = os.path.join(project_folder, folder, 'some.py')
         indhold_path = os.path.join(project_folder, folder, directory, 'indhold.py')
 
+        relative_folder_name = '.' + folder
         app_name = project_namespace + '.' + 'app'
         utils_name = project_namespace + '.' + 'utils'
         exceptions_name = project_namespace + '.' + 'exceptions'
@@ -51,3 +53,46 @@ class ProjectHandlerTest(unittest.TestCase):
         self.assertIn(indhold_tuple, modules)
 
         self.assertEqual(len(modules), 5)
+
+    def test_get_modules_and_packages(self):
+        project_folder = os.path.normpath(os.path.join('example', 'test_project'))
+
+        project_namespace = 'test_project'
+        folder = 'folder'
+        directory = 'directory'
+
+        modules = get_modules_and_packages(project_folder)
+
+        folder_path = os.path.join(project_folder, folder)
+        app_path = os.path.join(project_folder, 'app.py')
+        exceptions_path = os.path.join(project_folder, 'exceptions.py')
+        utils_path = os.path.join(project_folder,'utils.py')
+        directory_path = os.path.join(project_folder, folder, directory)
+        some_path = os.path.join(project_folder, folder, 'some.py')
+        indhold_path = os.path.join(project_folder, folder, directory, 'indhold.py')
+
+        relative_folder_name = '.' + folder
+        app_name = project_namespace + '.' + 'app'
+        exceptions_name = project_namespace + '.' + 'exceptions'
+        utils_name = project_namespace + '.' + 'utils'
+        relative_directory_name = '.' + folder + '.' + directory
+        some_name = project_namespace + '.' + folder + '.some'
+        indhold_name = project_namespace + '.' + folder + '.' + directory + '.indhold'
+
+        folder_tuple = (relative_folder_name[1:], folder_path, relative_folder_name)
+        app_tuple = (app_name, app_path)
+        exceptions_tuple = (exceptions_name, exceptions_path)
+        utils_tuple = (utils_name, utils_path)
+        directory_tuple = (relative_directory_name[1:], directory_path, relative_directory_name)
+        some_tuple = (some_name, some_path)
+        indhold_tuple = (indhold_name, indhold_path)
+
+        self.assertIn(folder_tuple, modules)
+        self.assertIn(app_tuple, modules)
+        self.assertIn(exceptions_tuple, modules)
+        self.assertIn(utils_tuple, modules)
+        self.assertIn(folder_tuple, modules)
+        self.assertIn(some_tuple, modules)
+        self.assertIn(indhold_tuple, modules)
+
+        self.assertEqual(len(modules), 7)

--- a/tests/vars_visitor_test.py
+++ b/tests/vars_visitor_test.py
@@ -5,7 +5,7 @@ from pyt.vars_visitor import VarsVisitor
 
 
 class VarsVisitorTestCase(unittest.TestCase):
-    '''Baseclass for VarsVisitor tests'''
+    """Baseclass for VarsVisitor tests"""
 
     def perform_vars_on_expression(self, expr):
         obj = ast.parse(expr)

--- a/tests/vulnerabilities_across_files_test.py
+++ b/tests/vulnerabilities_across_files_test.py
@@ -1,0 +1,69 @@
+import ast
+import os
+
+from .base_test_case import BaseTestCase
+from pyt import trigger_definitions_parser, vulnerabilities
+from pyt.ast_helper import get_call_names_as_string
+from pyt.base_cfg import Node
+from pyt.constraint_table import constraint_table, initialize_constraint_table
+from pyt.fixed_point import analyse
+from pyt.flask_adaptor import FlaskAdaptor
+from pyt.lattice import Lattice
+from pyt.project_handler import get_directory_modules, get_modules
+from pyt.reaching_definitions_taint import ReachingDefinitionsTaintAnalysis
+
+
+class EngineTest(BaseTestCase):
+    def run_analysis(self, path):
+        path = os.path.normpath(path)
+
+        project_modules = get_modules(os.path.dirname(path))
+        local_modules = get_directory_modules(os.path.dirname(path))
+
+        self.cfg_create_from_file(path, project_modules, local_modules)
+
+        cfg_list = [self.cfg]
+
+        FlaskAdaptor(cfg_list, [], [])
+
+        initialize_constraint_table(cfg_list)
+
+        analyse(cfg_list, analysis_type=ReachingDefinitionsTaintAnalysis)
+
+        return vulnerabilities.find_vulnerabilities(cfg_list, ReachingDefinitionsTaintAnalysis)
+
+    def test_find_vulnerabilities_absolute_from_file_command_injection(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/absolute_from_file_command_injection.py')
+
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+
+    def test_find_vulnerabilities_absolute_from_file_command_injection_2(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/absolute_from_file_command_injection_2.py')
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+
+    def test_no_false_positive_absolute_from_file_command_injection_3(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/no_false_positive_absolute_from_file_command_injection_3.py')
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=0)
+
+    # This fails due to a false positive in get_vulnerability
+    # def test_absolute_from_file_does_not_exist(self):
+    #     vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/absolute_from_file_does_not_exist.py')
+    #     self.assert_length(vulnerability_log.vulnerabilities, expected_length=0)
+
+    def test_find_vulnerabilities_import_file_command_injection(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/import_file_command_injection.py')
+
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+
+    def test_find_vulnerabilities_import_file_command_injection_2(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/import_file_command_injection_2.py')
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+
+    def test_no_false_positive_import_file_command_injection_3(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/no_false_positive_import_file_command_injection_3.py')
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=0)
+
+    # This fails due to a false positive in get_vulnerability
+    # def test_import_file_does_not_exist(self):
+    #     vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/import_file_does_not_exist.py')
+    #     self.assert_length(vulnerability_log.vulnerabilities, expected_length=0)

--- a/tests/vulnerabilities_test.py
+++ b/tests/vulnerabilities_test.py
@@ -179,3 +179,11 @@ class EngineTest(BaseTestCase):
     def test_find_vulnerabilities_command_injection(self):
         vulnerability_log = self.run_analysis('example/vulnerable_code/command_injection.py')
         self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+
+    def test_find_vulnerabilities_inter_command_injection(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code/inter_command_injection.py')
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+
+    def test_find_vulnerabilities_inter_command_injection_2(self):
+        vulnerability_log = self.run_analysis('example/vulnerable_code/inter_command_injection_2.py')
+        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)


### PR DESCRIPTION
This PR started as adding support for relative imports, but naturally became an inter-procedural PR including tests for things I haven't done yet like init files, `__all__`, `from foo import *` with style and  random improvements e.g. `project_handler_test` along the way.


A few of the small things:

- `get_python_modules` -> `get_modules` because I added `get_modules_and_packages`

- `is_python_module -> is_python_file`

- `add all tuples to project handler test`

- `double-quotes all around, for consistent multi-line comments`