### PR TITLE
[ui] fixed prog name from __main__.py to python -m pyt

### DIFF
--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -33,7 +33,7 @@ from .save import (
 from .vulnerabilities import find_vulnerabilities
 
 
-parser = argparse.ArgumentParser()
+parser = argparse.ArgumentParser(prog='python -m pyt')
 parser.set_defaults(which='')
 
 subparsers = parser.add_subparsers()


### PR DESCRIPTION
This seems to fix https://github.com/python-security/pyt/issues/42 although when it's on PyPI maybe we'll change it to just `pyt` instead of `python -m pyt`.