### PR TITLE
Support for output in Json format

### DIFF
--- a/func_counter.py
+++ b/func_counter.py
@@ -20,14 +20,14 @@ class Counter(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         if node.name in functions:
-            node.name += '¤'
+            node.name += '~'
         functions[node.name] = len(node.body)
         for n in node.body:
             self.visit(n)
 
     def visit_ClassDef(self, node):
         if node.name in classes:
-            node.name += '¤'
+            node.name += '~'
         classes[node.name] = len(node.body)
         for n in node.body:
             self.visit(n)

--- a/pyt/analysis_base.py
+++ b/pyt/analysis_base.py
@@ -1,5 +1,9 @@
 """This module contains a base class for the analysis component used in PyT."""
-from abc import ABCMeta, abstractmethod
+
+from abc import (
+    ABCMeta,
+    abstractmethod
+)
 
 
 class AnalysisBase(metaclass=ABCMeta):

--- a/pyt/ast_helper.py
+++ b/pyt/ast_helper.py
@@ -1,5 +1,6 @@
 """This module contains helper function.
 Useful when working with the ast module."""
+
 import ast
 import os
 import subprocess

--- a/pyt/draw.py
+++ b/pyt/draw.py
@@ -1,4 +1,5 @@
 """Draws CFG."""
+
 import argparse
 from itertools import permutations
 from subprocess import call
@@ -103,7 +104,6 @@ def draw_cfg(cfg, output_filename='output'):
 
 
 class Node():
-
     def __init__(self, s, parent, children=None):
         self.s = s
         self.parent = parent

--- a/pyt/expr_visitor.py
+++ b/pyt/expr_visitor.py
@@ -451,7 +451,7 @@ class ExprVisitor(StmtVisitor):
         for node in function_nodes:
             # Only `Return`s and `Raise`s can be of type ConnectToExitNode
             if isinstance(node, ConnectToExitNode):
-                # Create e.g. ¤call_1 = ret_func_foo RestoreNode
+                # Create e.g. ~call_1 = ret_func_foo RestoreNode
                 LHS = CALL_IDENTIFIER + 'call_' + str(saved_function_call_index)
                 RHS = 'ret_' + get_call_names_as_string(call_node.func)
                 return_node = RestoreNode(
@@ -478,11 +478,11 @@ class ExprVisitor(StmtVisitor):
         Visit and get function nodes. (visit_and_get_function_nodes)
         Loop through each save_N_LHS node and create an e.g.
             foo = save_1_foo or, if foo was a call arg, foo = arg_mapping[foo]. (restore_saved_local_scope)
-        Create e.g. ¤call_1 = ret_func_foo RestoreNode. (return_handler)
+        Create e.g. ~call_1 = ret_func_foo RestoreNode. (return_handler)
 
         Notes:
             Page 31 in the original thesis, but changed a little.
-            We don't have to return the ¤call_1 = ret_func_foo RestoreNode made in return_handler,
+            We don't have to return the ~call_1 = ret_func_foo RestoreNode made in return_handler,
                 because it's the last node anyway, that we return in this function.
             e.g. ret_func_foo gets assigned to visit_Return.
 

--- a/pyt/formatters/json.py
+++ b/pyt/formatters/json.py
@@ -1,0 +1,33 @@
+"""This formatter outputs the issues in JSON."""
+
+import json
+from datetime import datetime
+
+
+def report(
+    vulnerabilities,
+    fileobj
+):
+    """
+    Prints issues in JSON format.
+
+    Args:
+        vulnerabilities: list of vulnerabilities to report
+        fileobj: The output file object, which may be sys.stdout
+    """
+    TZ_AGNOSTIC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+    time_string = datetime.utcnow().strftime(TZ_AGNOSTIC_FORMAT)
+
+    machine_output = {
+        'generated_at': time_string,
+        'vulnerabilities': [vuln.as_dict() for vuln in vulnerabilities]
+    }
+
+    result = json.dumps(
+        machine_output,
+        indent=4,
+        sort_keys=True
+    )
+
+    with fileobj:
+        fileobj.write(result)

--- a/pyt/formatters/text.py
+++ b/pyt/formatters/text.py
@@ -1,0 +1,23 @@
+"""This formatter outputs the issues as plain text."""
+
+
+def report(
+	vulnerabilities,
+	fileobj
+):
+	"""
+	Prints issues in text format.
+
+	Args:
+		vulnerabilities: list of vulnerabilities to report
+		fileobj: The output file object, which may be sys.stdout
+	"""
+	number_of_vulnerabilities = len(vulnerabilities)
+	with fileobj:
+		if number_of_vulnerabilities == 1:
+			fileobj.write('%s vulnerability found:' % number_of_vulnerabilities)
+		else:
+			fileobj.write('%s vulnerabilities found:' % number_of_vulnerabilities)
+
+		for i, vulnerability in enumerate(vulnerabilities, start=1):
+			fileobj.write('Vulnerability {}:\n{}\n'.format(i, vulnerability))

--- a/pyt/framework_adaptor.py
+++ b/pyt/framework_adaptor.py
@@ -1,13 +1,11 @@
 """A generic framework adaptor that leaves route criteria to the caller."""
+
 import ast
 
 from .ast_helper import Arguments
 from .expr_visitor import make_cfg
 from .module_definitions import project_definitions
-from .node_types import (
-    AssignmentNode,
-    TaintedNode
-)
+from .node_types import TaintedNode
 
 
 class FrameworkAdaptor():

--- a/pyt/github_search.py
+++ b/pyt/github_search.py
@@ -197,7 +197,7 @@ def get_dates(start_date, end_date=date.today(), interval=7):
                                       delta.days % interval))
 
 
-def scan_github(search_string, start_date, analysis_type, analyse_repo_func, csv_path, ui_mode):
+def scan_github(search_string, start_date, analysis_type, analyse_repo_func, csv_path, ui_mode, other_args):
     analyse_repo = analyse_repo_func
     for d in get_dates(start_date, interval=7):
         q = Query(SEARCH_REPO_URL, search_string,
@@ -214,27 +214,27 @@ def scan_github(search_string, start_date, analysis_type, analyse_repo_func, csv
                 try:
                     r.clone()
                 except NoEntryPathError as err:
-                    save_repo_scan(repo, r.path, vulnerability_log=None, error=err)
+                    save_repo_scan(repo, r.path, vulnerabilities=None, error=err)
                     continue
                 except:
-                    save_repo_scan(repo, r.path, vulnerability_log=None, error='Other Error Unknown while cloning :-(')
+                    save_repo_scan(repo, r.path, vulnerabilities=None, error='Other Error Unknown while cloning :-(')
                     continue
                 try:
-                    vulnerability_log = analyse_repo(r, analysis_type, ui_mode)
-                    if vulnerability_log.vulnerabilities:
-                        save_repo_scan(repo, r.path, vulnerability_log)
+                    vulnerabilities = analyse_repo(other_args, r, analysis_type, ui_mode)
+                    if vulnerabilities:
+                        save_repo_scan(repo, r.path, vulnerabilities)
                         add_repo_to_csv(csv_path, r)
                     else:
-                        save_repo_scan(repo, r.path, vulnerability_log=None)
+                        save_repo_scan(repo, r.path, vulnerabilities=None)
                     r.clean_up()
                 except SyntaxError as err:
-                    save_repo_scan(repo, r.path, vulnerability_log=None, error=err)
+                    save_repo_scan(repo, r.path, vulnerabilities=None, error=err)
                 except IOError as err:
-                    save_repo_scan(repo, r.path, vulnerability_log=None, error=err)
+                    save_repo_scan(repo, r.path, vulnerabilities=None, error=err)
                 except AttributeError as err:
-                    save_repo_scan(repo, r.path, vulnerability_log=None, error=err)
+                    save_repo_scan(repo, r.path, vulnerabilities=None, error=err)
                 except:
-                    save_repo_scan(repo, r.path, vulnerability_log=None, error='Other Error Unknown :-(')
+                    save_repo_scan(repo, r.path, vulnerabilities=None, error='Other Error Unknown :-(')
 
 if __name__ == '__main__':
     for x in get_dates(date(2010, 1, 1), interval=93):

--- a/pyt/liveness.py
+++ b/pyt/liveness.py
@@ -64,7 +64,7 @@ class LivenessAnalysis(AnalysisBase):
     def add_vars_assignment(self, JOIN, cfg_node):
         rvars = list()
         if isinstance(cfg_node, BBorBInode):
-            # A conscience decision was made not to include e.g. ¤call_N's in RHS vars
+            # A conscience decision was made not to include e.g. ~call_N's in RHS vars
             rvars.extend(cfg_node.right_hand_side_variables)
         else:
             vv = VarsVisitor()

--- a/pyt/module_definitions.py
+++ b/pyt/module_definitions.py
@@ -1,5 +1,6 @@
 """This module handles module definitions
  which basically is a list of module definition."""
+
 import ast
 
 

--- a/pyt/node_types.py
+++ b/pyt/node_types.py
@@ -47,6 +47,13 @@ class Node():
         self.ingoing = list()
         self.outgoing = list()
 
+    def as_dict(self):
+        return {
+            'label': self.label.encode('utf-8').decode('utf-8'),
+            'line_number': self.line_number,
+            'path': self.path,
+        }
+
     def connect(self, successor):
         """Connect this node to its successor node by
         setting its outgoing and the successors ingoing."""
@@ -132,8 +139,8 @@ class RaiseNode(Node, ConnectToExitNode):
     """CFG Node that represents a Raise statement."""
 
     def __init__(self, ast_node, *, line_number, path):
-        label = LabelVisitor()
-        label.visit(ast_node)
+        label_visitor = LabelVisitor()
+        label_visitor.visit(ast_node)
 
         super().__init__(
             label_visitor.result,

--- a/pyt/save.py
+++ b/pyt/save.py
@@ -1,7 +1,11 @@
 import os
 from datetime import datetime
 
-from .definition_chains import build_def_use_chain, build_use_def_chain
+from .definition_chains import (
+    build_def_use_chain,
+    build_use_def_chain
+)
+from .formatters import text
 from .lattice import Lattice
 from .node_types import Node
 
@@ -52,13 +56,13 @@ def insert_node(node):
             fd.write('NULL')
         fd.write(');')
 
-def create_database(cfg_list, vulnerability_log):
+def create_database(cfg_list, vulnerabilities):
     create_nodes_table()
     for cfg in cfg_list:
         for node in cfg.nodes:
             insert_node(node)
     create_vulnerabilities_table()
-    for vulnerability in vulnerability_log.vulnerabilities:
+    for vulnerability in vulnerabilities:
         insert_vulnerability(vulnerability)
 
 
@@ -136,33 +140,19 @@ def lattice_to_file(cfg_list, analysis_type):
                 fd.write('{} -> {}{}'.format(bin(v), str(k), os.linesep))
 
 
-def write_vlog_to_file(fd, vulnerability_log):
-    for i, vulnerability in enumerate(vulnerability_log.vulnerabilities,
-                                      start=1):
-        fd.write('Vulnerability {}:\n{}{}{}'
-                 .format(i, vulnerability, os.linesep, os.linesep))
-
-
-def vulnerabilities_to_file(vulnerability_log):
+def vulnerabilities_to_file(vulnerabilities):
     with Output('vulnerabilities.pyt') as fd:
-        number_of_vulnerabilities = len(vulnerability_log.vulnerabilities)
-        if number_of_vulnerabilities == 1:
-            fd.write('{} vulnerability found:{}'
-                     .format(number_of_vulnerabilities, os.linesep))
-        else:
-            fd.write('{} vulnerabilities found:{}'
-                     .format(number_of_vulnerabilities, os.linesep))
-        write_vlog_to_file(fd, vulnerability_log)
+        text.report(vulnerabilities, fd)
 
 
-def save_repo_scan(repo, entry_path, vulnerability_log, error=None):
+def save_repo_scan(repo, entry_path, vulnerabilities, error=None):
     with open('scan.pyt', 'a') as fd:
         fd.write('{}{}'.format(repo.name, os.linesep))
         fd.write('{}{}'.format(repo.url, os.linesep))
         fd.write('Entry file: {}{}'.format(entry_path, os.linesep))
         fd.write('Scanned: {}{}'.format(datetime.now(), os.linesep))
-        if vulnerability_log:
-            write_vlog_to_file(fd, vulnerability_log)
+        if vulnerabilities:
+            text.report(vulnerabilities, fd)
         else:
             fd.write('No vulnerabilities found.{}'.format(os.linesep))
         if error:

--- a/pyt/stmt_visitor.py
+++ b/pyt/stmt_visitor.py
@@ -529,7 +529,7 @@ class StmtVisitor(ast.NodeVisitor):
         Nothing gets assigned to ret_func_foo in the builtin/blackbox case.
 
         Increments self.function_call_index each time it is called, we can refer to it as N in the comments.
-        Create e.g. ¤call_1 = ret_func_foo RestoreNode.
+        Create e.g. ~call_1 = ret_func_foo RestoreNode.
 
         Create e.g. temp_N_def_arg1 = call_arg1_label_visitor.result for each argument.
         Visit the arguments if they're calls. (save_def_args_in_temp)
@@ -554,7 +554,7 @@ class StmtVisitor(ast.NodeVisitor):
 
         index = call_label.result.find('(')
 
-        # Create e.g. ¤call_1 = ret_func_foo
+        # Create e.g. ~call_1 = ret_func_foo
         LHS = CALL_IDENTIFIER + 'call_' + str(saved_function_call_index)
         RHS = 'ret_' + call_label.result[:index] + '('
 

--- a/pyt/stmt_visitor_helper.py
+++ b/pyt/stmt_visitor_helper.py
@@ -10,7 +10,7 @@ from .node_types import (
 )
 
 
-CALL_IDENTIFIER = '¤'
+CALL_IDENTIFIER = '~'
 ConnectStatements = namedtuple(
     'ConnectStatements',
     (

--- a/pyt/vulnerability_helper.py
+++ b/pyt/vulnerability_helper.py
@@ -1,57 +1,39 @@
-"""This module contains vulnerability helpers.
-
-Mostly is contains logs to give precise information
- about where a vulnerability is located.
-The log is printed to standard output.
+"""This module contains vulnerability types and helpers.
 
 It is only used in vulnerabilities.py
 """
 from enum import Enum
 
 
-class VulnerabilityLog():
-    """Log that consists of vulnerabilities."""
-
-    def __init__(self):
-        """Initialise list of vulnerabilities."""
-        self.vulnerabilities = list()
-
-    def append(self, vulnerability):
-        """Add vulnerability to the vulnerabilities list."""
-        self.vulnerabilities.append(vulnerability)
-
-    def print_report(self):
-        """Print list of vulnerabilities."""
-        number_of_vulnerabilities = len(self.vulnerabilities)
-        if number_of_vulnerabilities == 1:
-            print('%s vulnerability found:' % number_of_vulnerabilities)
-        else:
-            print('%s vulnerabilities found:' % number_of_vulnerabilities)
-
-        for i, vulnerability in enumerate(self.vulnerabilities, start=1):
-            print('Vulnerability {}:\n{}\n'.format(i, vulnerability))
+class VulnerabilityType(Enum):
+    FALSE = 0
+    SANITISED = 1
+    TRUE = 2
+    UNKNOWN = 3
 
 
-class Reassigned():
-    def __init__(self, reassignment_nodes):
-        self.reassignment_nodes = reassignment_nodes
+def vuln_factory(vulnerability_type):
+    if vulnerability_type == VulnerabilityType.UNKNOWN:
+        return UnknownVulnerability
+    elif vulnerability_type == VulnerabilityType.SANITISED:
+        return SanitisedVulnerability
+    else:
+        return Vulnerability
 
-    def __str__(self):
-        reassignment = ''
-        if self.reassignment_nodes:
-            reassignment += '\nReassigned in:\n\t'
-            reassignment += '\n\t'.join([
-                'File: ' + node.path + '\n' +
-                '\t > Line ' + str(node.line_number) + ': ' + node.label
-                for node in self.reassignment_nodes
-            ])
-        return reassignment
+
+def _get_reassignment_str(reassignment_nodes):
+    reassignments = ''
+    if reassignment_nodes:
+        reassignments += '\nReassigned in:\n\t'
+        reassignments += '\n\t'.join([
+            'File: ' + node.path + '\n' +
+            '\t > Line ' + str(node.line_number) + ': ' + node.label
+            for node in reassignment_nodes
+        ])
+    return reassignments
 
 
 class Vulnerability():
-    """Vulnerability containing the source and the sources trigger word,
-    the sink and the sinks trigger word."""
-
     def __init__(
         self,
         source,
@@ -77,7 +59,7 @@ class Vulnerability():
 
     def __str__(self):
         """Pretty printing of a vulnerability."""
-        reassigned_str = Reassigned(self.reassignment_nodes)
+        reassigned_str = _get_reassignment_str(self.reassignment_nodes)
         return (
             'File: {}\n'
             ' > User input at line {}, trigger word "{}":\n'
@@ -92,67 +74,58 @@ class Vulnerability():
             )
         )
 
+    def as_dict(self):
+        return {
+            'source': self.source.as_dict(),
+            'source_trigger_word': self.source_trigger_word,
+            'sink': self.sink.as_dict(),
+            'sink_trigger_word': self.sink_trigger_word,
+            'type': self.__class__.__name__,
+            'reassignment_nodes': [node.as_dict() for node in self.reassignment_nodes]
+        }
+
 
 class SanitisedVulnerability(Vulnerability):
-    """A sanitised vulnerability containing the source and the sources
-    trigger word, the sink and the sinks trigger word.
-    Also containing the sanitiser."""
-
     def __init__(
         self,
-        source,
-        source_trigger_word,
-        sink,
-        sink_trigger_word,
-        reassignment_nodes,
+        confident,
         sanitiser,
-        definite
+        **kwargs
     ):
-        """Set source, sink and sanitiser information."""
-        super().__init__(
-            source,
-            source_trigger_word,
-            sink,
-            sink_trigger_word,
-            reassignment_nodes
-        )
+        super().__init__(**kwargs)
+        self.confident = confident
         self.sanitiser = sanitiser
-        self.definite = definite
 
     def __str__(self):
         """Pretty printing of a vulnerability."""
         return (
             super().__str__() +
             '\nThis vulnerability is ' +
-            ('' if self.definite else 'potentially ') +
+            ('' if self.confident else 'potentially ') +
             'sanitised by: ' +
             str(self.sanitiser)
         )
 
+    def as_dict(self):
+        output = super().as_dict()
+        output['sanitiser'] = self.sanitiser.as_dict()
+        output['confident'] = self.confident
+        return output
+
 
 class UnknownVulnerability(Vulnerability):
-    """An unknown vulnerability containing the source and the sources
-    trigger word, the sink and the sinks trigger word.
-    Also containing the blackbox assignment."""
-
     def __init__(
         self,
-        source,
-        source_trigger_word,
-        sink,
-        sink_trigger_word,
-        reassignment_nodes,
-        unknown_assignment
+        unknown_assignment,
+        **kwargs
     ):
-        """Set source, sink and blackbox assignment information."""
-        super().__init__(
-            source,
-            source_trigger_word,
-            sink,
-            sink_trigger_word,
-            reassignment_nodes
-        )
+        super().__init__(**kwargs)
         self.unknown_assignment = unknown_assignment
+
+    def as_dict(self):
+        output = super().as_dict()
+        output['unknown_assignment'] = self.unknown_assignment.as_dict()
+        return output
 
     def __str__(self):
         """Pretty printing of a vulnerability."""
@@ -161,19 +134,3 @@ class UnknownVulnerability(Vulnerability):
             '\nThis vulnerability is unknown due to: ' +
             str(self.unknown_assignment)
         )
-
-
-class VulnerabilityType(Enum):
-    FALSE = 0
-    SANITISED = 1
-    TRUE = 2
-    UNKNOWN = 3
-
-
-def vuln_factory(vulnerability_type):
-    if vulnerability_type == VulnerabilityType.UNKNOWN:
-        return UnknownVulnerability
-    elif vulnerability_type == VulnerabilityType.SANITISED:
-        return SanitisedVulnerability
-    else:
-        return Vulnerability

--- a/tests/cfg_test.py
+++ b/tests/cfg_test.py
@@ -73,10 +73,10 @@ class CFGForTest(BaseTestCase):
         exit_node = 7
 
         self.assertEqual(self.cfg.nodes[for_node].label,'for x in range(3):')
-        self.assertEqual(self.cfg.nodes[body_1].label, '¤call_1 = ret_print(x)')
+        self.assertEqual(self.cfg.nodes[body_1].label, '~call_1 = ret_print(x)')
         self.assertEqual(self.cfg.nodes[body_2].label, 'y += 1')
-        self.assertEqual(self.cfg.nodes[else_body_1].label, "¤call_2 = ret_print('Final: %s' % x)")
-        self.assertEqual(self.cfg.nodes[else_body_2].label, '¤call_3 = ret_print(y)')
+        self.assertEqual(self.cfg.nodes[else_body_1].label, "~call_2 = ret_print('Final: %s' % x)")
+        self.assertEqual(self.cfg.nodes[else_body_2].label, '~call_3 = ret_print(y)')
         self.assertEqual(self.cfg.nodes[next_node].label, 'x = 3')
 
         self.assertInCfg([(for_node, entry),
@@ -124,10 +124,10 @@ class CFGForTest(BaseTestCase):
 
         self.nodes = self.cfg_list_to_dict(self.cfg.nodes)
         for_node = self.nodes['for x in range(3):']
-        body_1 = self.nodes['¤call_1 = ret_print(x)']
+        body_1 = self.nodes['~call_1 = ret_print(x)']
         body_2 = self.nodes['y += 1']
-        else_body_1 = self.nodes["¤call_2 = ret_print('Final: %s' % x)"]
-        else_body_2 = self.nodes['¤call_3 = ret_print(y)']
+        else_body_1 = self.nodes["~call_2 = ret_print('Final: %s' % x)"]
+        else_body_2 = self.nodes['~call_3 = ret_print(y)']
         next_node = self.nodes['x = 3']
 
         self.assertLineNumber(for_node, 1)
@@ -200,14 +200,14 @@ class CFGTryTest(BaseTestCase):
         print_a5 = 3
         except_im = 4
         except_im_body_1 = 5
-        value_equal_call_2 = 6 # value = ¤call_2
+        value_equal_call_2 = 6 # value = ~call_2
         print_wagyu = 7
         save_node = 8
         assign_to_temp = 9
         assign_from_temp = 10
         function_entry = 11
         ret_of_subprocess_call = 12
-        ret_does_this_kill_us_equal_call_5 = 13 # ret_does_this_kill_us = ¤call_5
+        ret_does_this_kill_us_equal_call_5 = 13 # ret_does_this_kill_us = ~call_5
         function_exit = 14
         restore_node = 15
         return_handler = 16
@@ -530,10 +530,10 @@ class CFGAssignmentMultiTest(BaseTestCase):
         # This assert means N should be connected to N+1
         self.assertInCfg([(1,0),(2,1),(3,2),(4,3),(5,4)])
 
-        self.assertEqual(assignment_to_call1.label, '¤call_1 = ret_int(5)')
-        self.assertEqual(assignment_to_x.label, 'x = ¤call_1')
-        self.assertEqual(assignment_to_call2.label, '¤call_2 = ret_int(4)')
-        self.assertEqual(assignment_to_y.label, 'y = ¤call_2')
+        self.assertEqual(assignment_to_call1.label, '~call_1 = ret_int(5)')
+        self.assertEqual(assignment_to_x.label, 'x = ~call_1')
+        self.assertEqual(assignment_to_call2.label, '~call_2 = ret_int(4)')
+        self.assertEqual(assignment_to_y.label, 'y = ~call_2')
 
     def test_assignment_multi_target_line_numbers(self):
         self.cfg_create_from_file('example/example_inputs/assignment_two_targets.py')
@@ -585,7 +585,7 @@ class CFGAssignmentMultiTest(BaseTestCase):
         self.assert_length(self.cfg.nodes, expected_length=length)
 
         call = self.cfg.nodes[1]
-        self.assertEqual(call.label, "¤call_1 = ret_''.join((x.n for x in range(16)))")
+        self.assertEqual(call.label, "~call_1 = ret_''.join((x.n for x in range(16)))")
 
         l = zip(range(1, length), range(length))
 
@@ -684,7 +684,7 @@ class CFGFunctionNodeTest(BaseTestCase):
     def test_function_line_numbers(self):
         path = 'example/example_inputs/simple_function.py'
         self.cfg_create_from_file(path)
-        
+
         input_call = self.cfg.nodes[1]
         y_assignment = self.cfg.nodes[2]
         save_y = self.cfg.nodes[3]
@@ -1116,7 +1116,7 @@ class CFGCallWithAttributeTest(BaseTestCase):
         self.assert_length(self.cfg.nodes, expected_length=length)
 
         call = self.cfg.nodes[2]
-        self.assertEqual(call.label, "¤call_1 = ret_request.args.get('param', 'not set')")
+        self.assertEqual(call.label, "~call_1 = ret_request.args.get('param', 'not set')")
 
         l = zip(range(1, length), range(length))
         self.assertInCfg(list(l))

--- a/tests/command_line_test.py
+++ b/tests/command_line_test.py
@@ -25,9 +25,9 @@ class CommandLineTest(BaseTestCase):
         EXPECTED = """usage: python -m pyt [-h] (-f FILEPATH | -gr GIT_REPOS) [-pr PROJECT_ROOT]
                      [-d] [-o OUTPUT_FILENAME] [-csv CSV_PATH]
                      [-p | -vp | -trim | -i] [-t TRIGGER_WORD_FILE]
-                     [-b BLACKBOX_MAPPING_FILE] [-py2] [-l LOG_LEVEL]
+                     [-m BLACKBOX_MAPPING_FILE] [-py2] [-l LOG_LEVEL]
                      [-a ADAPTOR] [-db] [-dl DRAW_LATTICE [DRAW_LATTICE ...]]
-                     [-li | -re | -rt] [-ppm]
+                     [-j] [-li | -re | -rt] [-ppm]
                      {save,github_search} ...\n""" + \
                      "python -m pyt: error: one of the arguments " + \
                      "-f/--filepath -gr/--git-repos is required\n"

--- a/tests/import_test.py
+++ b/tests/import_test.py
@@ -25,8 +25,8 @@ class ImportTest(BaseTestCase):
                     "Function Entry B",
                     "ret_B = s",
                     "Exit B",
-                    "¤call_1 = ret_B",
-                    "b = ¤call_1",
+                    "~call_1 = ret_B",
+                    "b = ~call_1",
                     "save_2_b = b",
                     "temp_2_s = 'sss'",
                     "s = temp_2_s",
@@ -34,8 +34,8 @@ class ImportTest(BaseTestCase):
                     "ret_A.B = s",
                     "Exit A.B",
                     "b = save_2_b",
-                    "¤call_2 = ret_A.B",
-                    "c = ¤call_2",
+                    "~call_2 = ret_A.B",
+                    "c = ~call_2",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -59,8 +59,8 @@ class ImportTest(BaseTestCase):
                     "Function Entry B",
                     "ret_B = s",
                     "Exit B",
-                    "¤call_1 = ret_B",
-                    "b = ¤call_1",
+                    "~call_1 = ret_B",
+                    "b = ~call_1",
                     "save_2_b = b",
                     "temp_2_s = 'sss'",
                     "s = temp_2_s",
@@ -68,8 +68,8 @@ class ImportTest(BaseTestCase):
                     "ret_foo.B = s",
                     "Exit A.B",
                     "b = save_2_b",
-                    "¤call_2 = ret_foo.B",
-                    "c = ¤call_2",
+                    "~call_2 = ret_foo.B",
+                    "c = ~call_2",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -91,19 +91,19 @@ class ImportTest(BaseTestCase):
                     "Function Entry B",
                     "ret_B = s",
                     "Exit B",
-                    "¤call_1 = ret_B",
+                    "~call_1 = ret_B",
                     "temp_2_s = 'minute'",
                     "s = temp_2_s",
                     "Function Entry C",
                     "ret_C = s + 'see'",
                     "Exit C",
-                    "¤call_2 = ret_C",
+                    "~call_2 = ret_C",
                     "temp_3_s = 'IPA'",
                     "s = temp_3_s",
                     "Function Entry D",
                     "ret_D = s + 'dee'",
                     "Exit D",
-                    "¤call_3 = ret_D",
+                    "~call_3 = ret_D",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -129,13 +129,13 @@ class ImportTest(BaseTestCase):
                     "Module Exit folder",
                     "Module Exit package_star",
                     "Function Entry A.cobia",
-                    "¤call_2 = ret_print('A')",
+                    "~call_2 = ret_print('A')",
                     "Exit A.cobia",
                     "Function Entry B.al",
-                    "¤call_4 = ret_print('B')",
+                    "~call_4 = ret_print('B')",
                     "Exit B.al",
                     "Function Entry folder.C.pastor",
-                    "¤call_6 = ret_print('C')",
+                    "~call_6 = ret_print('C')",
                     "Exit folder.C.pastor",
                     "Exit module"]
 
@@ -162,13 +162,13 @@ class ImportTest(BaseTestCase):
                     "Module Exit folder",
                     "Module Exit package_star_with_alias",
                     "Function Entry husk.cobia",
-                    "¤call_2 = ret_print('A')",
+                    "~call_2 = ret_print('A')",
                     "Exit husk.cobia",
                     "Function Entry meringue.al",
-                    "¤call_4 = ret_print('B')",
+                    "~call_4 = ret_print('B')",
                     "Exit meringue.al",
                     "Function Entry corn.mousse.pastor",
-                    "¤call_6 = ret_print('C')",
+                    "~call_6 = ret_print('C')",
                     "Exit corn.mousse.pastor",
                     "Exit module"]
 
@@ -193,7 +193,7 @@ class ImportTest(BaseTestCase):
                     "Function Entry bar.H",
                     "ret_bar.H = s + 'end'",
                     "Exit bar.H",
-                    "¤call_1 = ret_bar.H",
+                    "~call_1 = ret_bar.H",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -217,8 +217,8 @@ class ImportTest(BaseTestCase):
                     "Function Entry B",
                     "ret_B = s",
                     "Exit B",
-                    "¤call_1 = ret_B",
-                    "b = ¤call_1",
+                    "~call_1 = ret_B",
+                    "b = ~call_1",
                     "save_2_b = b",
                     "temp_2_s = 'sss'",
                     "s = temp_2_s",
@@ -226,8 +226,8 @@ class ImportTest(BaseTestCase):
                     "ret_A.B = s",
                     "Exit A.B",
                     "b = save_2_b",
-                    "¤call_2 = ret_A.B",
-                    "c = ¤call_2",
+                    "~call_2 = ret_A.B",
+                    "c = ~call_2",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -262,8 +262,8 @@ class ImportTest(BaseTestCase):
                     "Function Entry H",
                     "ret_H = s + 'end'",
                     "Exit H",
-                    "¤call_1 = ret_H",
-                    "result = ¤call_1",
+                    "~call_1 = ret_H",
+                    "result = ~call_1",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -286,7 +286,7 @@ class ImportTest(BaseTestCase):
                     "Function Entry bar.H",
                     "ret_bar.H = s + 'end'",
                     "Exit bar.H",
-                    "¤call_1 = ret_bar.H",
+                    "~call_1 = ret_bar.H",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -309,8 +309,8 @@ class ImportTest(BaseTestCase):
                     'Function Entry A.B',
                     'ret_A.B = s',
                     'Exit A.B',
-                    '¤call_1 = ret_A.B',
-                    'c = ¤call_1',
+                    '~call_1 = ret_A.B',
+                    'c = ~call_1',
                     'Exit module']
 
 
@@ -334,8 +334,8 @@ class ImportTest(BaseTestCase):
                     'Function Entry A.B',
                     'ret_A.B = s',
                     'Exit A.B',
-                    '¤call_1 = ret_A.B',
-                    'c = ¤call_1',
+                    '~call_1 = ret_A.B',
+                    'c = ~call_1',
                     'Exit module']
 
 
@@ -365,8 +365,8 @@ class ImportTest(BaseTestCase):
                     "Function Entry A.cosme",
                     "ret_A.cosme = s + 'aaa'",
                     "Exit A.cosme",
-                    "¤call_1 = ret_A.cosme",
-                    "a = ¤call_1",
+                    "~call_1 = ret_A.cosme",
+                    "a = ~call_1",
                     "save_2_a = a",
                     "temp_2_s = 'mutton'",
                     "s = temp_2_s",
@@ -374,8 +374,8 @@ class ImportTest(BaseTestCase):
                     "ret_keens.foo = s + 'bee'",
                     "Exit B.foo",
                     "a = save_2_a",
-                    "¤call_2 = ret_keens.foo",
-                    "b = ¤call_2",
+                    "~call_2 = ret_keens.foo",
+                    "b = ~call_2",
                     "save_3_a = a",
                     "save_3_b = b",
                     "temp_3_s = 'tasting'",
@@ -385,8 +385,8 @@ class ImportTest(BaseTestCase):
                     "Exit C.foo",
                     "a = save_3_a",
                     "b = save_3_b",
-                    "¤call_3 = ret_per_se.foo",
-                    "c = ¤call_3",
+                    "~call_3 = ret_per_se.foo",
+                    "c = ~call_3",
                     "save_4_a = a",
                     "save_4_b = b",
                     "save_4_c = c",
@@ -398,8 +398,8 @@ class ImportTest(BaseTestCase):
                     "a = save_4_a",
                     "b = save_4_b",
                     "c = save_4_c",
-                    "¤call_4 = ret_duck_house.foo",
-                    "d = ¤call_4",
+                    "~call_4 = ret_duck_house.foo",
+                    "d = ~call_4",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):
@@ -422,8 +422,8 @@ class ImportTest(BaseTestCase):
                     "Function Entry B",
                     "ret_keens = s",
                     "Exit B",
-                    "¤call_1 = ret_keens",
-                    "a = ¤call_1",
+                    "~call_1 = ret_keens",
+                    "a = ~call_1",
                     "save_2_a = a",
                     "temp_2_s = 'tasting'",
                     "s = temp_2_s",
@@ -431,8 +431,8 @@ class ImportTest(BaseTestCase):
                     "ret_C = s + 'see'",
                     "Exit C",
                     "a = save_2_a",
-                    "¤call_2 = ret_C",
-                    "b = ¤call_2",
+                    "~call_2 = ret_C",
+                    "b = ~call_2",
                     "save_3_a = a",
                     "save_3_b = b",
                     "temp_3_s = 'peking'",
@@ -442,8 +442,8 @@ class ImportTest(BaseTestCase):
                     "Exit D",
                     "a = save_3_a",
                     "b = save_3_b",
-                    "¤call_3 = ret_duck_house",
-                    "c = ¤call_3",
+                    "~call_3 = ret_duck_house",
+                    "c = ~call_3",
                     "Exit module"]
 
 
@@ -467,7 +467,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit nested_folder_with_init",
                     "Module Exit package_with_function",
                     "Function Entry package_with_function.StarbucksVisitor",
-                    "¤call_2 = ret_print('Iced Mocha')",
+                    "~call_2 = ret_print('Iced Mocha')",
                     "Exit package_with_function.StarbucksVisitor",
                     "Exit module"]
 
@@ -491,7 +491,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit nested_folder_with_init",
                     "Module Exit package_with_function_and_alias",
                     "Function Entry package_with_function_and_alias.EatalyVisitor",
-                    "¤call_2 = ret_print('Iced Mocha')",
+                    "~call_2 = ret_print('Iced Mocha')",
                     "Exit package_with_function_and_alias.EatalyVisitor",
                     "Exit module"]
 
@@ -513,7 +513,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit Starbucks",
                     "Module Exit package_with_file",
                     "Function Entry package_with_file.Starbucks.Tea",
-                    "¤call_2 = ret_print('Teavana Green')",
+                    "~call_2 = ret_print('Teavana Green')",
                     "Exit package_with_file.Starbucks.Tea",
                     "Exit module"]
 
@@ -535,7 +535,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit Starbucks",
                     "Module Exit package_with_file_and_alias",
                     "Function Entry package_with_file_and_alias.Eataly.Tea",
-                    "¤call_2 = ret_print('Teavana Green')",
+                    "~call_2 = ret_print('Teavana Green')",
                     "Exit package_with_file_and_alias.Eataly.Tea",
                     "Exit module"]
 
@@ -559,7 +559,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit nested_folder_with_init",
                     "Module Exit package_with_folder",
                     "Function Entry package_with_folder.nested_folder_with_init.moose.fast",
-                    "¤call_2 = ret_print('real fast')",
+                    "~call_2 = ret_print('real fast')",
                     "Exit package_with_folder.nested_folder_with_init.moose.fast",
                     "Exit module"]
 
@@ -583,7 +583,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit nested_folder_with_init",
                     "Module Exit package_with_folder_and_alias",
                     "Function Entry package_with_folder_and_alias.heyo.moose.fast",
-                    "¤call_2 = ret_print('real fast')",
+                    "~call_2 = ret_print('real fast')",
                     "Exit package_with_folder_and_alias.heyo.moose.fast",
                     "Exit module"]
 
@@ -607,7 +607,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit nested_folder_with_init",
                     "Module Exit package_with_function",
                     "Function Entry StarbucksVisitor",
-                    "¤call_2 = ret_print('Iced Mocha')",
+                    "~call_2 = ret_print('Iced Mocha')",
                     "Exit StarbucksVisitor",
                     "Exit module"]
 
@@ -631,7 +631,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit nested_folder_with_init",
                     "Module Exit package_with_function_and_alias",
                     "Function Entry EatalyVisitor",
-                    "¤call_2 = ret_print('Iced Mocha')",
+                    "~call_2 = ret_print('Iced Mocha')",
                     "Exit EatalyVisitor",
                     "Exit module"]
 
@@ -653,7 +653,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit Starbucks",
                     "Module Exit package_with_file",
                     "Function Entry Starbucks.Tea",
-                    "¤call_2 = ret_print('Teavana Green')",
+                    "~call_2 = ret_print('Teavana Green')",
                     "Exit Starbucks.Tea",
                     "Exit module"]
 
@@ -675,7 +675,7 @@ class ImportTest(BaseTestCase):
                     "Module Exit Starbucks",
                     "Module Exit package_with_file_and_alias",
                     "Function Entry Eataly.Tea",
-                    "¤call_2 = ret_print('Teavana Green')",
+                    "~call_2 = ret_print('Teavana Green')",
                     "Exit Eataly.Tea",
                     "Exit module"]
 

--- a/tests/nested_functions_test.py
+++ b/tests/nested_functions_test.py
@@ -25,16 +25,16 @@ class NestedTest(BaseTestCase):
                     "ret_inner = inner_ret_val",
                     "Exit inner",
                     "foo = save_2_foo",
-                    "¤call_2 = ret_inner",
-                    "temp_1_outer_arg = ¤call_2",
+                    "~call_2 = ret_inner",
+                    "temp_1_outer_arg = ~call_2",
                     "outer_arg = temp_1_outer_arg",
                     "Function Entry outer",
                     "outer_ret_val = outer_arg + 'hey'",
                     "ret_outer = outer_ret_val",
                     "Exit outer",
                     "foo = save_1_foo",
-                    "¤call_1 = ret_outer",
-                    "abc = ¤call_1",
+                    "~call_1 = ret_outer",
+                    "abc = ~call_1",
                     "Exit module"]
 
         for node, expected_label in zip(self.cfg.nodes, EXPECTED):

--- a/tests/reaching_definitions_taint_test.py
+++ b/tests/reaching_definitions_taint_test.py
@@ -11,11 +11,11 @@ class ReachingDefinitionsTaintTest(AnalysisBaseTestCase):
 
         EXPECTED = [
                     "Label: Entry module:",
-                    "Label: ¤call_1 = ret_input():  Label: ¤call_1 = ret_input()",
-                    "Label: x = ¤call_1:  Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: y = x - 1:  Label: y = x - 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: ¤call_2 = ret_print(x):  Label: ¤call_2 = ret_print(x), Label: y = x - 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: Exit module:  Label: ¤call_2 = ret_print(x), Label: y = x - 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()"
+                    "Label: ~call_1 = ret_input():  Label: ~call_1 = ret_input()",
+                    "Label: x = ~call_1:  Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: y = x - 1:  Label: y = x - 1, Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: ~call_2 = ret_print(x):  Label: ~call_2 = ret_print(x), Label: y = x - 1, Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: Exit module:  Label: ~call_2 = ret_print(x), Label: y = x - 1, Label: x = ~call_1, Label: ~call_1 = ret_input()"
                    ]
         i = 0
         for k, v in constraint_table.items():
@@ -30,12 +30,12 @@ class ReachingDefinitionsTaintTest(AnalysisBaseTestCase):
 
         EXPECTED = [
                     "Label: Entry module:",
-                    "Label: ¤call_1 = ret_input():  Label: ¤call_1 = ret_input()",
-                    "Label: x = ¤call_1:  Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: if x > 0::  Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: y = x + 1:  Label: y = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: ¤call_2 = ret_print(x):  Label: ¤call_2 = ret_print(x), Label: y = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: Exit module:  Label: ¤call_2 = ret_print(x), Label: y = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()"
+                    "Label: ~call_1 = ret_input():  Label: ~call_1 = ret_input()",
+                    "Label: x = ~call_1:  Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: if x > 0::  Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: y = x + 1:  Label: y = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: ~call_2 = ret_print(x):  Label: ~call_2 = ret_print(x), Label: y = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: Exit module:  Label: ~call_2 = ret_print(x), Label: y = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_input()"
                    ]
         i = 0
         for k, v in constraint_table.items():
@@ -49,20 +49,20 @@ class ReachingDefinitionsTaintTest(AnalysisBaseTestCase):
 
         EXPECTED = [
                     "Label: Entry module:",
-                    "Label: ¤call_1 = ret_input():  Label: ¤call_1 = ret_input()",
-                    "Label: x = ¤call_1:  Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: ¤call_2 = ret_int(x):  Label: ¤call_2 = ret_int(x), Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: x = ¤call_2:  Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: while x > 1::  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: y = x / 2:  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: if y > 3::  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: x = x - y:  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: z = x - 4:  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: if z > 0::  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: x = x / 2:  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: z = z - 1:  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: ¤call_3 = ret_print(x):  Label: ¤call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: Exit module:  Label: ¤call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()"
+                    "Label: ~call_1 = ret_input():  Label: ~call_1 = ret_input()",
+                    "Label: x = ~call_1:  Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: ~call_2 = ret_int(x):  Label: ~call_2 = ret_int(x), Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: x = ~call_2:  Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: while x > 1::  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: y = x / 2:  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: if y > 3::  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: x = x - y:  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: z = x - 4:  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: if z > 0::  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: x = x / 2:  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: z = z - 1:  Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: ~call_3 = ret_print(x):  Label: ~call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: Exit module:  Label: ~call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()"
                    ]
         i = 0
         for k, v in constraint_table.items():
@@ -90,16 +90,16 @@ class ReachingDefinitionsTaintTest(AnalysisBaseTestCase):
 
         EXPECTED = [
                     "Label: Entry module: ",
-                    "Label: ¤call_2 = ret_input():  Label: ¤call_2 = ret_input()",
-                    "Label: ¤call_1 = ret_int(¤call_2):  Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()",
-                    "Label: x = ¤call_1:  Label: x = ¤call_1, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()",
-                    "Label: while x < 10::  Label: x = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input(",
-                    "Label: x = x + 1:  Label: x = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()",
-                    "Label: if x == 5::  Label: x = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()",
-                    "Label: BreakNode:  Label: x = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()",
-                    "Label: x = 6:  Label: x = 6, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()",
-                    "Label: ¤call_3 = ret_print(x):  Label: ¤call_3 = ret_print(x), Label: x = 6, Label: x = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()",
-                    "Label: Exit module:  Label: ¤call_3 = ret_print(x), Label: x = 6, Label: x = x + 1, Label: x = ¤call_1, Label: ¤call_1 = ret_int(¤call_2), Label: ¤call_2 = ret_input()"                    
+                    "Label: ~call_2 = ret_input():  Label: ~call_2 = ret_input()",
+                    "Label: ~call_1 = ret_int(~call_2):  Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()",
+                    "Label: x = ~call_1:  Label: x = ~call_1, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()",
+                    "Label: while x < 10::  Label: x = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input(",
+                    "Label: x = x + 1:  Label: x = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()",
+                    "Label: if x == 5::  Label: x = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()",
+                    "Label: BreakNode:  Label: x = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()",
+                    "Label: x = 6:  Label: x = 6, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()",
+                    "Label: ~call_3 = ret_print(x):  Label: ~call_3 = ret_print(x), Label: x = 6, Label: x = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()",
+                    "Label: Exit module:  Label: ~call_3 = ret_print(x), Label: x = 6, Label: x = x + 1, Label: x = ~call_1, Label: ~call_1 = ret_int(~call_2), Label: ~call_2 = ret_input()"
                    ]
         i = 0
         for k, v in constraint_table.items():

--- a/tests/reaching_definitions_test.py
+++ b/tests/reaching_definitions_test.py
@@ -10,11 +10,11 @@ class ReachingDefinitionsTest(AnalysisBaseTestCase):
 
         EXPECTED = [
                     "Label: Entry module: ",
-                    "Label: ¤call_1 = ret_input():  Label: ¤call_1 = ret_input()",
-                    "Label: x = ¤call_1:  Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: y = x - 1:  Label: y = x - 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: ¤call_2 = ret_print(x):  Label: ¤call_2 = ret_print(x), Label: y = x - 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: Exit module:  Label: ¤call_2 = ret_print(x), Label: y = x - 1, Label: x = ¤call_1, Label: ¤call_1 = ret_input()",                    
+                    "Label: ~call_1 = ret_input():  Label: ~call_1 = ret_input()",
+                    "Label: x = ~call_1:  Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: y = x - 1:  Label: y = x - 1, Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: ~call_2 = ret_print(x):  Label: ~call_2 = ret_print(x), Label: y = x - 1, Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: Exit module:  Label: ~call_2 = ret_print(x), Label: y = x - 1, Label: x = ~call_1, Label: ~call_1 = ret_input()",
                    ]
         i = 0
         for k, v in constraint_table.items():
@@ -28,20 +28,20 @@ class ReachingDefinitionsTest(AnalysisBaseTestCase):
 
         EXPECTED = [
                     "Label: Entry module: ",
-                    "Label: ¤call_1 = ret_input():  Label: ¤call_1 = ret_input()",
-                    "Label: x = ¤call_1:  Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: ¤call_2 = ret_int(x):  Label: ¤call_2 = ret_int(x), Label: x = ¤call_1, Label: ¤call_1 = ret_input()",
-                    "Label: x = ¤call_2:  Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: while x > 1::  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: y = x / 2:  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: if y > 3::  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: x = x - y:  Label: z = z - 1, Label: x = x - y, Label: y = x / 2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: z = x - 4:  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: if z > 0::  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: x = x / 2:  Label: x = x / 2, Label: z = x - 4, Label: y = x / 2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: z = z - 1:  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: ¤call_3 = ret_print(x):  Label: ¤call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
-                    "Label: Exit module:  Label: ¤call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ¤call_2, Label: ¤call_2 = ret_int(x), Label: ¤call_1 = ret_input()",
+                    "Label: ~call_1 = ret_input():  Label: ~call_1 = ret_input()",
+                    "Label: x = ~call_1:  Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: ~call_2 = ret_int(x):  Label: ~call_2 = ret_int(x), Label: x = ~call_1, Label: ~call_1 = ret_input()",
+                    "Label: x = ~call_2:  Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: while x > 1::  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: y = x / 2:  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: if y > 3::  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: x = x - y:  Label: z = z - 1, Label: x = x - y, Label: y = x / 2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: z = x - 4:  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: if z > 0::  Label: x = x / 2, Label: z = x - 4, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: x = x / 2:  Label: x = x / 2, Label: z = x - 4, Label: y = x / 2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: z = z - 1:  Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: ~call_3 = ret_print(x):  Label: ~call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
+                    "Label: Exit module:  Label: ~call_3 = ret_print(x), Label: z = z - 1, Label: x = x / 2, Label: x = x - y, Label: y = x / 2, Label: x = ~call_2, Label: ~call_2 = ret_int(x), Label: ~call_1 = ret_input()",
                    ]
         i = 0
         for k, v in constraint_table.items():

--- a/tests/vulnerabilities_across_files_test.py
+++ b/tests/vulnerabilities_across_files_test.py
@@ -1,23 +1,19 @@
-import ast
 import os
 
 from .base_test_case import BaseTestCase
-from pyt import trigger_definitions_parser, vulnerabilities
 from pyt.argument_helpers import (
     default_blackbox_mapping_file,
     default_trigger_word_file,
     UImode,
     VulnerabilityFiles
 )
-from pyt.ast_helper import get_call_names_as_string
-from pyt.constraint_table import constraint_table, initialize_constraint_table
+from pyt.constraint_table import initialize_constraint_table
 from pyt.fixed_point import analyse
 from pyt.framework_adaptor import FrameworkAdaptor
 from pyt.framework_helper import is_flask_route_function
-from pyt.lattice import Lattice
-from pyt.node_types import Node
 from pyt.project_handler import get_directory_modules, get_modules
 from pyt.reaching_definitions_taint import ReachingDefinitionsTaintAnalysis
+from pyt.vulnerabilities import find_vulnerabilities
 
 
 class EngineTest(BaseTestCase):
@@ -37,7 +33,7 @@ class EngineTest(BaseTestCase):
 
         analyse(cfg_list, analysis_type=ReachingDefinitionsTaintAnalysis)
 
-        return vulnerabilities.find_vulnerabilities(
+        return find_vulnerabilities(
             cfg_list,
             ReachingDefinitionsTaintAnalysis,
             UImode.NORMAL,
@@ -48,47 +44,47 @@ class EngineTest(BaseTestCase):
         )
 
     def test_find_vulnerabilities_absolute_from_file_command_injection(self):
-        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/absolute_from_file_command_injection.py')
+        vulnerabilities = self.run_analysis('example/vulnerable_code_across_files/absolute_from_file_command_injection.py')
 
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+        self.assert_length(vulnerabilities, expected_length=1)
 
     def test_find_vulnerabilities_absolute_from_file_command_injection_2(self):
-        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/absolute_from_file_command_injection_2.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+        vulnerabilities = self.run_analysis('example/vulnerable_code_across_files/absolute_from_file_command_injection_2.py')
+        self.assert_length(vulnerabilities, expected_length=1)
 
     def test_no_false_positive_absolute_from_file_command_injection_3(self):
-        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/no_false_positive_absolute_from_file_command_injection_3.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=0)
+        vulnerabilities = self.run_analysis('example/vulnerable_code_across_files/no_false_positive_absolute_from_file_command_injection_3.py')
+        self.assert_length(vulnerabilities, expected_length=0)
 
     def test_blackbox_library_call(self):
-        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/blackbox_library_call.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
-        vulnerability_description = str(vulnerability_log.vulnerabilities[0])
+        vulnerabilities = self.run_analysis('example/vulnerable_code_across_files/blackbox_library_call.py')
+        self.assert_length(vulnerabilities, expected_length=1)
+        vulnerability_description = str(vulnerabilities[0])
         EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: example/vulnerable_code_across_files/blackbox_library_call.py
              > User input at line 12, trigger word "request.args.get(":
-                ¤call_1 = ret_request.args.get('suggestion')
+                ~call_1 = ret_request.args.get('suggestion')
             Reassigned in:
                 File: example/vulnerable_code_across_files/blackbox_library_call.py
-                 > Line 12: param = ¤call_1
+                 > Line 12: param = ~call_1
                 File: example/vulnerable_code_across_files/blackbox_library_call.py
-                 > Line 15: ¤call_2 = ret_scrypt.encrypt('echo ' + param + ' >> ' + 'menu.txt', 'password')
+                 > Line 15: ~call_2 = ret_scrypt.encrypt('echo ' + param + ' >> ' + 'menu.txt', 'password')
                 File: example/vulnerable_code_across_files/blackbox_library_call.py
-                 > Line 15: command = ¤call_2
+                 > Line 15: command = ~call_2
                 File: example/vulnerable_code_across_files/blackbox_library_call.py
                  > Line 16: hey = command
             File: example/vulnerable_code_across_files/blackbox_library_call.py
              > reaches line 17, trigger word "subprocess.call(":
-                ¤call_3 = ret_subprocess.call(hey, shell=True)
-            This vulnerability is unknown due to:  Label: ¤call_2 = ret_scrypt.encrypt('echo ' + param + ' >> ' + 'menu.txt', 'password')
+                ~call_3 = ret_subprocess.call(hey, shell=True)
+            This vulnerability is unknown due to:  Label: ~call_2 = ret_scrypt.encrypt('echo ' + param + ' >> ' + 'menu.txt', 'password')
         """
 
         self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
 
     def test_builtin_with_user_defined_inner(self):
-        vulnerability_log = self.run_analysis('example/nested_functions_code/builtin_with_user_defined_inner.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
-        vulnerability_description = str(vulnerability_log.vulnerabilities[0])
+        vulnerabilities = self.run_analysis('example/nested_functions_code/builtin_with_user_defined_inner.py')
+        self.assert_length(vulnerabilities, expected_length=1)
+        vulnerability_description = str(vulnerabilities[0])
         EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: example/nested_functions_code/builtin_with_user_defined_inner.py
              > User input at line 16, trigger word "form[":
@@ -107,37 +103,37 @@ class EngineTest(BaseTestCase):
                 File: example/nested_functions_code/builtin_with_user_defined_inner.py
                  > Line 10: req_param = save_2_req_param
                 File: example/nested_functions_code/builtin_with_user_defined_inner.py
-                 > Line 19: ¤call_2 = ret_inner
+                 > Line 19: ~call_2 = ret_inner
                 File: example/nested_functions_code/builtin_with_user_defined_inner.py
-                 > Line 19: ¤call_1 = ret_scrypt.encrypt(¤call_2)
+                 > Line 19: ~call_1 = ret_scrypt.encrypt(~call_2)
                 File: example/nested_functions_code/builtin_with_user_defined_inner.py
-                 > Line 19: foo = ¤call_1
+                 > Line 19: foo = ~call_1
             File: example/nested_functions_code/builtin_with_user_defined_inner.py
              > reaches line 20, trigger word "subprocess.call(":
-                ¤call_3 = ret_subprocess.call(foo, shell=True)
-            This vulnerability is unknown due to:  Label: ¤call_1 = ret_scrypt.encrypt(¤call_2)
+                ~call_3 = ret_subprocess.call(foo, shell=True)
+            This vulnerability is unknown due to:  Label: ~call_1 = ret_scrypt.encrypt(~call_2)
         """
         self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
 
     def test_sink_with_result_of_blackbox_nested(self):
-        vulnerability_log = self.run_analysis('example/nested_functions_code/sink_with_result_of_blackbox_nested.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
-        vulnerability_description = str(vulnerability_log.vulnerabilities[0])
+        vulnerabilities = self.run_analysis('example/nested_functions_code/sink_with_result_of_blackbox_nested.py')
+        self.assert_length(vulnerabilities, expected_length=1)
+        vulnerability_description = str(vulnerabilities[0])
         EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
              > User input at line 12, trigger word "form[":
                 req_param = request.form['suggestion']
             Reassigned in:
                 File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
-                 > Line 13: ¤call_2 = ret_scrypt.encrypt(req_param)
+                 > Line 13: ~call_2 = ret_scrypt.encrypt(req_param)
                 File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
-                 > Line 13: ¤call_1 = ret_scrypt.encrypt(¤call_2)
+                 > Line 13: ~call_1 = ret_scrypt.encrypt(~call_2)
                 File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
-                 > Line 13: result = ¤call_1
+                 > Line 13: result = ~call_1
             File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
              > reaches line 14, trigger word "subprocess.call(":
-                ¤call_3 = ret_subprocess.call(result, shell=True)
-            This vulnerability is unknown due to:  Label: ¤call_2 = ret_scrypt.encrypt(req_param)
+                ~call_3 = ret_subprocess.call(result, shell=True)
+            This vulnerability is unknown due to:  Label: ~call_2 = ret_scrypt.encrypt(req_param)
         """
         OTHER_EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
@@ -145,24 +141,24 @@ class EngineTest(BaseTestCase):
                 req_param = request.form['suggestion']
             Reassigned in:
                 File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
-                 > Line 13: ¤call_2 = ret_scrypt.encrypt(req_param)
+                 > Line 13: ~call_2 = ret_scrypt.encrypt(req_param)
                 File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
-                 > Line 13: ¤call_1 = ret_scrypt.encrypt(¤call_2)
+                 > Line 13: ~call_1 = ret_scrypt.encrypt(~call_2)
                 File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
-                 > Line 13: result = ¤call_1
+                 > Line 13: result = ~call_1
             File: example/nested_functions_code/sink_with_result_of_blackbox_nested.py
              > reaches line 14, trigger word "subprocess.call(":
-                ¤call_3 = ret_subprocess.call(result, shell=True)
-            This vulnerability is unknown due to:  Label: ¤call_1 = ret_scrypt.encrypt(¤call_2)
+                ~call_3 = ret_subprocess.call(result, shell=True)
+            This vulnerability is unknown due to:  Label: ~call_1 = ret_scrypt.encrypt(~call_2)
         """
         self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
                         or
                         self.string_compare_alpha(vulnerability_description, OTHER_EXPECTED_VULNERABILITY_DESCRIPTION))
 
     def test_sink_with_result_of_user_defined_nested(self):
-        vulnerability_log = self.run_analysis('example/nested_functions_code/sink_with_result_of_user_defined_nested.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
-        vulnerability_description = str(vulnerability_log.vulnerabilities[0])
+        vulnerabilities = self.run_analysis('example/nested_functions_code/sink_with_result_of_user_defined_nested.py')
+        self.assert_length(vulnerabilities, expected_length=1)
+        vulnerability_description = str(vulnerabilities[0])
         EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
              > User input at line 16, trigger word "form[":
@@ -183,9 +179,9 @@ class EngineTest(BaseTestCase):
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
                  > Line 10: req_param = save_2_req_param
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
-                 > Line 17: ¤call_2 = ret_inner
+                 > Line 17: ~call_2 = ret_inner
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
-                 > Line 17: temp_1_outer_arg = ¤call_2
+                 > Line 17: temp_1_outer_arg = ~call_2
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
                  > Line 6: outer_arg = temp_1_outer_arg
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
@@ -195,32 +191,32 @@ class EngineTest(BaseTestCase):
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
                  > Line 6: req_param = save_1_req_param
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
-                 > Line 17: ¤call_1 = ret_outer
+                 > Line 17: ~call_1 = ret_outer
                 File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
-                 > Line 17: result = ¤call_1
+                 > Line 17: result = ~call_1
             File: example/nested_functions_code/sink_with_result_of_user_defined_nested.py
              > reaches line 18, trigger word "subprocess.call(":
-                ¤call_3 = ret_subprocess.call(result, shell=True)
+                ~call_3 = ret_subprocess.call(result, shell=True)
         """
         self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
-        
+
     def test_sink_with_blackbox_inner(self):
-        vulnerability_log = self.run_analysis('example/nested_functions_code/sink_with_blackbox_inner.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
-        vulnerability_description = str(vulnerability_log.vulnerabilities[0])
+        vulnerabilities = self.run_analysis('example/nested_functions_code/sink_with_blackbox_inner.py')
+        self.assert_length(vulnerabilities, expected_length=1)
+        vulnerability_description = str(vulnerabilities[0])
         EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: example/nested_functions_code/sink_with_blackbox_inner.py
              > User input at line 12, trigger word "form[":
                 req_param = request.form['suggestion']
             Reassigned in:
                 File: example/nested_functions_code/sink_with_blackbox_inner.py
-                 > Line 14: ¤call_3 = ret_scrypt.encypt(req_param)
+                 > Line 14: ~call_3 = ret_scrypt.encypt(req_param)
                 File: example/nested_functions_code/sink_with_blackbox_inner.py
-                 > Line 14: ¤call_2 = ret_scrypt.encypt(¤call_3)
+                 > Line 14: ~call_2 = ret_scrypt.encypt(~call_3)
             File: example/nested_functions_code/sink_with_blackbox_inner.py
              > reaches line 14, trigger word "subprocess.call(":
-                ¤call_1 = ret_subprocess.call(¤call_2, shell=True)
-            This vulnerability is unknown due to:  Label: ¤call_2 = ret_scrypt.encypt(¤call_3)
+                ~call_1 = ret_subprocess.call(~call_2, shell=True)
+            This vulnerability is unknown due to:  Label: ~call_2 = ret_scrypt.encypt(~call_3)
         """
 
         OTHER_EXPECTED_VULNERABILITY_DESCRIPTION = """
@@ -229,22 +225,22 @@ class EngineTest(BaseTestCase):
                 req_param = request.form['suggestion']
             Reassigned in:
                 File: example/nested_functions_code/sink_with_blackbox_inner.py
-                 > Line 14: ¤call_3 = ret_scrypt.encypt(req_param)
+                 > Line 14: ~call_3 = ret_scrypt.encypt(req_param)
                 File: example/nested_functions_code/sink_with_blackbox_inner.py
-                 > Line 14: ¤call_2 = ret_scrypt.encypt(¤call_3)
+                 > Line 14: ~call_2 = ret_scrypt.encypt(~call_3)
             File: example/nested_functions_code/sink_with_blackbox_inner.py
              > reaches line 14, trigger word "subprocess.call(":
-                ¤call_1 = ret_subprocess.call(¤call_2, shell=True)
-            This vulnerability is unknown due to:  Label: ¤call_3 = ret_scrypt.encypt(req_param)
+                ~call_1 = ret_subprocess.call(~call_2, shell=True)
+            This vulnerability is unknown due to:  Label: ~call_3 = ret_scrypt.encypt(req_param)
         """
         self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
                         or
                         self.string_compare_alpha(vulnerability_description, OTHER_EXPECTED_VULNERABILITY_DESCRIPTION))
 
     def test_sink_with_user_defined_inner(self):
-        vulnerability_log = self.run_analysis('example/nested_functions_code/sink_with_user_defined_inner.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
-        vulnerability_description = str(vulnerability_log.vulnerabilities[0])
+        vulnerabilities = self.run_analysis('example/nested_functions_code/sink_with_user_defined_inner.py')
+        self.assert_length(vulnerabilities, expected_length=1)
+        vulnerability_description = str(vulnerabilities[0])
         EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: example/nested_functions_code/sink_with_user_defined_inner.py
              > User input at line 16, trigger word "form[":
@@ -265,9 +261,9 @@ class EngineTest(BaseTestCase):
                 File: example/nested_functions_code/sink_with_user_defined_inner.py
                  > Line 10: req_param = save_3_req_param
                 File: example/nested_functions_code/sink_with_user_defined_inner.py
-                 > Line 18: ¤call_3 = ret_inner
+                 > Line 18: ~call_3 = ret_inner
                 File: example/nested_functions_code/sink_with_user_defined_inner.py
-                 > Line 18: temp_2_outer_arg = ¤call_3
+                 > Line 18: temp_2_outer_arg = ~call_3
                 File: example/nested_functions_code/sink_with_user_defined_inner.py
                  > Line 6: outer_arg = temp_2_outer_arg
                 File: example/nested_functions_code/sink_with_user_defined_inner.py
@@ -277,22 +273,22 @@ class EngineTest(BaseTestCase):
                 File: example/nested_functions_code/sink_with_user_defined_inner.py
                  > Line 6: req_param = save_2_req_param
                 File: example/nested_functions_code/sink_with_user_defined_inner.py
-                 > Line 18: ¤call_2 = ret_outer
+                 > Line 18: ~call_2 = ret_outer
             File: example/nested_functions_code/sink_with_user_defined_inner.py
              > reaches line 18, trigger word "subprocess.call(":
-                ¤call_1 = ret_subprocess.call(¤call_2, shell=True)
+                ~call_1 = ret_subprocess.call(~call_2, shell=True)
         """
         self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
 
     def test_find_vulnerabilities_import_file_command_injection(self):
-        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/import_file_command_injection.py')
+        vulnerabilities = self.run_analysis('example/vulnerable_code_across_files/import_file_command_injection.py')
 
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+        self.assert_length(vulnerabilities, expected_length=1)
 
     def test_find_vulnerabilities_import_file_command_injection_2(self):
-        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/import_file_command_injection_2.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=1)
+        vulnerabilities = self.run_analysis('example/vulnerable_code_across_files/import_file_command_injection_2.py')
+        self.assert_length(vulnerabilities, expected_length=1)
 
     def test_no_false_positive_import_file_command_injection_3(self):
-        vulnerability_log = self.run_analysis('example/vulnerable_code_across_files/no_false_positive_import_file_command_injection_3.py')
-        self.assert_length(vulnerability_log.vulnerabilities, expected_length=0)
+        vulnerabilities = self.run_analysis('example/vulnerable_code_across_files/no_false_positive_import_file_command_injection_3.py')
+        self.assert_length(vulnerabilities, expected_length=0)


### PR DESCRIPTION
This aims to fix https://github.com/python-security/pyt/issues/84.

Delete VulnerabilityLog and print_report, make formatters/text.py and json.py, -j for JSON option, refactor CALL_IDENTIFIER to tilde because of /uUGLYNUMBERS json output, refactor super calls of the subclasses of Vulnerability to be silky smooth with kwargs, implement as_dict methods for Node and vulnerability types, make tests pass with these changes, fixed a few flake8y things.