### PR TITLE
Skip making self a TaintedNode

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@
     -   id: check-ast
     -   id: check-symlinks
     -   id: flake8
-        args: ['--ignore=E501']
+        args: ['--exclude=examples/*', '--ignore=E501,E741']

--- a/examples/example_inputs/def_with_self_as_first_arg.py
+++ b/examples/example_inputs/def_with_self_as_first_arg.py
@@ -1,0 +1,4 @@
+
+
+def my_data(self, foo, bar):
+	return redirect(self.something)

--- a/pyt/node_types.py
+++ b/pyt/node_types.py
@@ -176,6 +176,10 @@ class AssignmentNode(Node):
 
 
 class TaintedNode(AssignmentNode):
+    """CFG Node that represents a tainted node.
+
+    Only created in framework_adaptor.py and only used in `identify_triggers` of vulnerabilities.py
+    """
     pass
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,5 @@ deps = -rrequirements-dev.txt
 commands =
     coverage erase
     coverage run tests
-    coverage report --show-missing --fail-under 88
+    coverage report --show-missing --fail-under 89
     pre-commit run


### PR DESCRIPTION
vuln test for it,
flake8 vuln_test
88->89%

So in https://github.com/python-security/pyt/issues/113 @Ifatty brought up a good point, that we shouldn't mark self as tainted, b/c of false-positives.

In the future we can make it configurable.