### PR TITLE
Vars visitor handles python 3.5 dict syntax

### DIFF
--- a/pyt/helper_visitors/vars_visitor.py
+++ b/pyt/helper_visitors/vars_visitor.py
@@ -32,7 +32,8 @@ class VarsVisitor(ast.NodeVisitor):
 
     def visit_Dict(self, node):
         for k in node.keys:
-            self.visit(k)
+            if k is not None:
+                self.visit(k)
         for v in node.values:
             self.visit(v)
 

--- a/tests/helper_visitors/vars_visitor_test.py
+++ b/tests/helper_visitors/vars_visitor_test.py
@@ -136,3 +136,7 @@ class VarsVisitorTest(VarsVisitorTestCase):
                 await foo()
         """.lstrip())
         self.assertEqual(vars.result, [])
+
+    def test_visit_dict(self):
+        vars = self.perform_vars_on_expression('a = {k1: v1, k2: v2, **d1, **d2}')
+        self.assertEqual(vars.result, ['a', 'k1', 'k2', 'v1', 'v2', 'd1', 'd2'])


### PR DESCRIPTION
of the type `{'a': 1, **x}`. The `**x` will have key `None`.

Before it would crash.