### PR TITLE
Certain args, kwargs of sink functions are affected by taint

### DIFF
--- a/examples/vulnerable_code/sql/sqli.py
+++ b/examples/vulnerable_code/sql/sqli.py
@@ -38,5 +38,13 @@ def filtering():
         print(value.username, value.email)
     return 'Result is displayed in console.'
 
+@app.route('/users/<name>', methods=['DELETE'])
+def delete_user_dangerously(name):
+    query = "DELETE FROM user WHERE username = :name"
+    db.engine.execute(query, name=name)
+    print('Deleted')
+    return 'Deleted'
+
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/pyt/cfg/stmt_visitor.py
+++ b/pyt/cfg/stmt_visitor.py
@@ -573,6 +573,7 @@ class StmtVisitor(ast.NodeVisitor):
         call_node = BBorBInode(
             label='',
             left_hand_side=LHS,
+            ast_node=node,
             right_hand_side_variables=[],
             line_number=node.lineno,
             path=self.filenames[-1],

--- a/pyt/core/node_types.py
+++ b/pyt/core/node_types.py
@@ -202,7 +202,7 @@ class RestoreNode(AssignmentNode):
 class BBorBInode(AssignmentNode):
     """Node used for handling restore nodes returning from blackbox or builtin function calls."""
 
-    def __init__(self, label, left_hand_side, right_hand_side_variables, *, line_number, path, func_name):
+    def __init__(self, label, left_hand_side, ast_node, right_hand_side_variables, *, line_number, path, func_name):
         """Create a Restore node.
 
         Args:
@@ -213,7 +213,7 @@ class BBorBInode(AssignmentNode):
             path(string): Current filename.
             func_name(string): The string we will compare with the blackbox_mapping in vulnerabilities.py
         """
-        super().__init__(label, left_hand_side, None, right_hand_side_variables, line_number=line_number, path=path)
+        super().__init__(label, left_hand_side, ast_node, right_hand_side_variables, line_number=line_number, path=path)
         self.args = list()
         self.inner_most_call = self
         self.func_name = func_name

--- a/pyt/helper_visitors/__init__.py
+++ b/pyt/helper_visitors/__init__.py
@@ -1,9 +1,11 @@
+from .call_visitor import CallVisitor
 from .label_visitor import LabelVisitor
 from .right_hand_side_visitor import RHSVisitor
 from .vars_visitor import VarsVisitor
 
 
 __all__ = [
+    'CallVisitor',
     'LabelVisitor',
     'RHSVisitor',
     'VarsVisitor'

--- a/pyt/helper_visitors/call_visitor.py
+++ b/pyt/helper_visitors/call_visitor.py
@@ -1,0 +1,71 @@
+import ast
+import re
+from collections import defaultdict, namedtuple
+from itertools import count
+
+from ..core.ast_helper import get_call_names_as_string
+from .right_hand_side_visitor import RHSVisitor
+
+
+class CallVisitorResults(
+    namedtuple(
+        "CallVisitorResults",
+        ("args", "kwargs", "unknown_args", "unknown_kwargs")
+    )
+):
+    __slots__ = ()
+
+    def all_results(self):
+        for x in self.args:
+            yield from x
+        for x in self.kwargs.values():
+            yield from x
+        yield from self.unknown_args
+        yield from self.unknown_kwargs
+
+
+class CallVisitor(ast.NodeVisitor):
+    def __init__(self, trigger_str):
+        self.unknown_arg_visitor = RHSVisitor()
+        self.unknown_kwarg_visitor = RHSVisitor()
+        self.argument_visitors = defaultdict(lambda: RHSVisitor())
+        self._trigger_str = trigger_str
+
+    def visit_Call(self, call_node):
+        func_name = get_call_names_as_string(call_node.func)
+        trigger_re = r"(^|\.){}$".format(re.escape(self._trigger_str))
+        if re.search(trigger_re, func_name):
+            seen_starred = False
+            for index, arg in enumerate(call_node.args):
+                if isinstance(arg, ast.Starred):
+                    seen_starred = True
+                if seen_starred:
+                    self.unknown_arg_visitor.visit(arg)
+                else:
+                    self.argument_visitors[index].visit(arg)
+
+            for keyword in call_node.keywords:
+                if keyword.arg is None:
+                    self.unknown_kwarg_visitor.visit(keyword.value)
+                else:
+                    self.argument_visitors[keyword.arg].visit(keyword.value)
+        self.generic_visit(call_node)
+
+    @classmethod
+    def get_call_visit_results(cls, trigger_str, node):
+        visitor = cls(trigger_str)
+        visitor.visit(node)
+
+        arg_results = []
+        for i in count():
+            try:
+                arg_results.append(set(visitor.argument_visitors.pop(i).result))
+            except KeyError:
+                break
+
+        return CallVisitorResults(
+            arg_results,
+            {k: set(v.result) for k, v in visitor.argument_visitors.items()},
+            set(visitor.unknown_arg_visitor.result),
+            set(visitor.unknown_kwarg_visitor.result),
+        )

--- a/pyt/helper_visitors/right_hand_side_visitor.py
+++ b/pyt/helper_visitors/right_hand_side_visitor.py
@@ -21,3 +21,9 @@ class RHSVisitor(ast.NodeVisitor):
         if node.keywords:
             for keyword in node.keywords:
                 self.visit(keyword)
+
+    @classmethod
+    def result_for_node(cls, node):
+        visitor = cls()
+        visitor.visit(node)
+        return visitor.result

--- a/pyt/vulnerabilities/vulnerabilities.py
+++ b/pyt/vulnerabilities/vulnerabilities.py
@@ -16,7 +16,7 @@ from ..helper_visitors import (
     RHSVisitor,
     VarsVisitor
 )
-from .trigger_definitions_parser import parse
+from .trigger_definitions_parser import parse, Source
 from .vulnerability_helper import (
     Sanitiser,
     TriggerNode,
@@ -49,8 +49,7 @@ def identify_triggers(
     tainted_nodes = filter_cfg_nodes(cfg, TaintedNode)
     tainted_trigger_nodes = [
         TriggerNode(
-            'Framework function URL parameter',
-            sanitisers=None,
+            Source('Framework function URL parameter'),
             cfg_node=node
         ) for node in tainted_nodes
     ]
@@ -142,7 +141,7 @@ def find_triggers(
 
     Args:
         nodes(list[Node]): the nodes to find triggers in.
-        trigger_word_list(list[string]): list of trigger words to look for.
+        trigger_word_list(list[Union[Sink, Source]]): list of trigger words to look for.
         nosec_lines(set): lines with # nosec whitelisting
 
     Returns:
@@ -157,23 +156,21 @@ def find_triggers(
 
 def label_contains(
     node,
-    trigger_words
+    triggers
 ):
     """Determine if node contains any of the trigger_words provided.
 
     Args:
         node(Node): CFG node to check.
-        trigger_words(list[string]): list of trigger words to look for.
+        trigger_words(list[Union[Sink, Source]]): list of trigger words to look for.
 
     Returns:
         Iterable of TriggerNodes found. Can be multiple because multiple
         trigger_words can be in one node.
     """
-    for trigger_word_tuple in trigger_words:
-        if trigger_word_tuple[0] in node.label:
-            trigger_word = trigger_word_tuple[0]
-            sanitisers = trigger_word_tuple[1]
-            yield TriggerNode(trigger_word, sanitisers, node)
+    for trigger in triggers:
+        if trigger.trigger_word in node.label:
+            yield TriggerNode(trigger, node)
 
 
 def build_sanitiser_node_dict(

--- a/pyt/vulnerabilities/vulnerability_helper.py
+++ b/pyt/vulnerabilities/vulnerability_helper.py
@@ -164,15 +164,21 @@ Triggers = namedtuple(
 class TriggerNode():
     def __init__(
         self,
-        trigger_word,
-        sanitisers,
+        trigger,
         cfg_node,
         secondary_nodes=[]
     ):
-        self.trigger_word = trigger_word
-        self.sanitisers = sanitisers
+        self.trigger = trigger
         self.cfg_node = cfg_node
         self.secondary_nodes = secondary_nodes
+
+    @property
+    def trigger_word(self):
+        return self.trigger.trigger_word
+
+    @property
+    def sanitisers(self):
+        return self.trigger.sanitisers if hasattr(self.trigger, 'sanitisers') else []
 
     def append(self, cfg_node):
         if not cfg_node == self.cfg_node:

--- a/pyt/vulnerability_definitions/all_trigger_words.pyt
+++ b/pyt/vulnerability_definitions/all_trigger_words.pyt
@@ -1,6 +1,7 @@
 {
     "sources": [
         "request.args.get(",
+        "request.get_json(",
         "Markup(",
         "POST.get(",
         "GET.get(",

--- a/pyt/vulnerability_definitions/all_trigger_words.pyt
+++ b/pyt/vulnerability_definitions/all_trigger_words.pyt
@@ -1,34 +1,46 @@
-sources:
-request.args.get(
-Markup(
-POST.get(
-GET.get(
-META.get(
-POST[
-GET[
-META[
-FILES[
-.data
-form[
-form(
-mark_safe(
-cookies[
-files[
-SQLAlchemy
-
-sinks:
-replace( -> escape
-send_file( -> '..', '..' in
-execute(
-system(
-filter(
-subprocess.call(
-render_template(
-set_cookie(
-redirect(
-url_for(
-flash(
-jsonify(
-render(
-render_to_response(
-Popen(
+{
+    "sources": [
+        "request.args.get(",
+        "Markup(",
+        "POST.get(",
+        "GET.get(",
+        "META.get(",
+        "POST[",
+        "GET[",
+        "META[",
+        "FILES[",
+        ".data",
+        "form[",
+        "form(",
+        "mark_safe(",
+        "cookies[",
+        "files[",
+        "SQLAlchemy"
+    ],
+    "sinks": {
+        "replace(": {
+            "sanitisers": [
+                "escape"
+            ]
+        },
+        "send_file(": {
+            "sanitisers": [
+                "'..'",
+                "'..' in"
+            ]
+        },
+        "execute(": {},
+        "system(": {},
+        "filter(": {},
+        "subprocess.call(": {},
+        "render_template(": {},
+        "set_cookie(": {},
+        "redirect(": {},
+        "url_for(": {},
+        "flash(": {},
+        "jsonify(": {},
+        "render(": {},
+        "render_to_response(": {},
+        "Popen(": {}
+    }
+}

--- a/pyt/vulnerability_definitions/django_trigger_words.pyt
+++ b/pyt/vulnerability_definitions/django_trigger_words.pyt
@@ -1,32 +1,44 @@
-sources:
-POST.get(
-GET.get(
-META.get(
-POST[
-GET[
-META[
-FILES[
-.data
-form[
-form(
-mark_safe(
-cookies[
-files[
-SQLAlchemy
-
-sinks:
-replace( -> escape
-send_file( -> '..', '..' in
-execute(
-system(
-filter(
-subprocess.call(
-render_template(
-set_cookie(
-redirect(
-url_for(
-flash(
-jsonify(
-render(
-render_to_response(
-Popen(
+{
+    "sources": [
+        "POST.get(",
+        "GET.get(",
+        "META.get(",
+        "POST[",
+        "GET[",
+        "META[",
+        "FILES[",
+        ".data",
+        "form[",
+        "form(",
+        "mark_safe(",
+        "cookies[",
+        "files[",
+        "SQLAlchemy"
+    ],
+    "sinks": {
+        "replace(": {
+            "sanitisers": [
+                "escape"
+            ]
+        },
+        "send_file(": {
+            "sanitisers": [
+                "'..'",
+                "'..' in"
+            ]
+        },
+        "execute(": {},
+        "system(": {},
+        "filter(": {},
+        "subprocess.call(": {},
+        "render_template(": {},
+        "set_cookie(": {},
+        "redirect(": {},
+        "url_for(": {},
+        "flash(": {},
+        "jsonify(": {},
+        "render(": {},
+        "render_to_response(": {},
+        "Popen(": {}
+    }
+}

--- a/pyt/vulnerability_definitions/flask_trigger_words.pyt
+++ b/pyt/vulnerability_definitions/flask_trigger_words.pyt
@@ -1,6 +1,7 @@
 {
     "sources": [
         "request.args.get(",
+        "request.get_json(",
         ".data",
         "form[",
         "form(",

--- a/pyt/vulnerability_definitions/flask_trigger_words.pyt
+++ b/pyt/vulnerability_definitions/flask_trigger_words.pyt
@@ -1,23 +1,35 @@
-sources:
-request.args.get(
-.data
-form[
-form(
-Markup(
-cookies[
-files[
-SQLAlchemy
-
-sinks:
-replace( -> escape
-send_file( -> '..', '..' in
-execute(
-system(
-filter(
-subprocess.call(
-render_template(
-set_cookie(
-redirect(
-url_for(
-flash(
-jsonify(
+{
+    "sources": [
+        "request.args.get(",
+        ".data",
+        "form[",
+        "form(",
+        "Markup(",
+        "cookies[",
+        "files[",
+        "SQLAlchemy"
+    ],
+    "sinks": {
+        "replace(": {
+            "sanitisers": [
+                "escape"
+            ]
+        },
+        "send_file(": {
+            "sanitisers": [
+                "'..'",
+                "'..' in"
+            ]
+        },
+        "execute(": {},
+        "system(": {},
+        "filter(": {},
+        "subprocess.call(": {},
+        "render_template(": {},
+        "set_cookie(": {},
+        "redirect(": {},
+        "url_for(": {},
+        "flash(": {},
+        "jsonify(": {}
+    }
+}

--- a/pyt/vulnerability_definitions/test_positions.pyt
+++ b/pyt/vulnerability_definitions/test_positions.pyt
@@ -1,0 +1,28 @@
+{
+    "sources": [
+        "request.args.get(",
+        "make_taint("
+    ],
+    "sinks": {
+        "normal(": {},
+        "execute(": {
+            "unlisted_args_propagate": false,
+            "arg_list": [
+                0
+            ],
+            "unlisted_kwargs_propagate": false,
+            "kwarg_list": [
+                "text"
+            ]
+        },
+        "run(": {
+            "kwarg_list": [
+                "non_propagating"
+            ],
+            "arg_list": [
+                2,
+                3
+            ]
+        }
+    }
+}

--- a/pyt/vulnerability_definitions/test_triggers.pyt
+++ b/pyt/vulnerability_definitions/test_triggers.pyt
@@ -1,7 +1,20 @@
-sources:
-input
-
-sinks:
-eval -> sanitise
-horse -> japan, host, kost
-valmue
+{
+    "sources": [
+        "input"
+    ],
+    "sinks": {
+        "eval(": {
+            "sanitisers": [
+                "sanitise"
+            ]
+        },
+        "horse(": {
+            "sanitisers": [
+                "japan",
+                "host",
+                "kost"
+            ]
+        },
+        "valmue": {}
+    }
+}

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -9,9 +9,9 @@ from pyt.core.module_definitions import project_definitions
 class BaseTestCase(unittest.TestCase):
     """A base class that has helper methods for testing PyT."""
 
-    def assert_length(self, _list, *, expected_length):
+    def assert_length(self, _list, *, expected_length, msg=None):
         actual_length = len(_list)
-        self.assertEqual(expected_length, actual_length)
+        self.assertEqual(expected_length, actual_length, msg=msg)
 
     def cfg_create_from_file(
         self,
@@ -26,4 +26,18 @@ class BaseTestCase(unittest.TestCase):
             project_modules,
             local_modules,
             filename
+        )
+
+    def cfg_create_from_ast(
+        self,
+        ast_tree,
+        project_modules=list(),
+        local_modules=list()
+    ):
+        project_definitions.clear()
+        self.cfg = make_cfg(
+            ast_tree,
+            project_modules,
+            local_modules,
+            filename='?'
         )

--- a/tests/helper_visitors/call_visitor_test.py
+++ b/tests/helper_visitors/call_visitor_test.py
@@ -1,0 +1,52 @@
+import ast
+import unittest
+
+from pyt.helper_visitors import CallVisitor
+
+
+class CallVisitorTest(unittest.TestCase):
+    def get_results(self, call_name, expr):
+        tree = ast.parse(expr)
+        return CallVisitor.get_call_visit_results(trigger_str=call_name, node=tree)
+
+    def test_basic(self):
+        call_args = self.get_results('func', 'func(a, b, x=c)')
+        self.assertEqual(call_args.args, [{'a'}, {'b'}])
+        self.assertEqual(call_args.kwargs, {'x': {'c'}})
+        self.assertEqual(call_args.unknown_args, set())
+        self.assertEqual(call_args.unknown_kwargs, set())
+
+    def test_visits_each_argument_recursively(self):
+        call_args = self.get_results('func', 'func(a + b, f(123), g(h(c=d)), e=i(123))')
+        self.assertEqual(call_args.args, [{'a', 'b'}, set(), {'d'}])
+        self.assertEqual(call_args.kwargs, {'e': set()})
+        self.assertEqual(call_args.unknown_args, set())
+        self.assertEqual(call_args.unknown_kwargs, set())
+
+    def test_merge_when_function_called_inside_own_arguments(self):
+        call_args = self.get_results('func', 'func(a + func(b, c, x=d), e)')
+        self.assertEqual(call_args.args, [{'a', 'b', 'c', 'd'}, {'c', 'e'}])
+        self.assertEqual(call_args.kwargs, {'x': {'d'}})
+        self.assertEqual(call_args.unknown_args, set())
+        self.assertEqual(call_args.unknown_kwargs, set())
+
+    def test_star_args_kwargs(self):
+        call_args = self.get_results('func', 'func(a, b, *c, *d, x=e, **f, **g)')
+        self.assertEqual(call_args.args, [{'a'}, {'b'}])
+        self.assertEqual(call_args.kwargs, {'x': {'e'}})
+        self.assertEqual(call_args.unknown_args, {'c', 'd'})
+        self.assertEqual(call_args.unknown_kwargs, {'f', 'g'})
+
+    def test_call_inside_comprehension(self):
+        call_args = self.get_results('func', '[row for row in db.func(a, b)]')
+        self.assertEqual(call_args.args, [{'a'}, {'b'}])
+        self.assertEqual(call_args.kwargs, {})
+        self.assertEqual(call_args.unknown_args, set())
+        self.assertEqual(call_args.unknown_kwargs, set())
+
+    def test_call_inside_comprehension_2(self):
+        call_args = self.get_results('func', '[func(a, b) for b in c]')
+        self.assertEqual(call_args.args, [{'a'}, {'b'}])
+        self.assertEqual(call_args.kwargs, {})
+        self.assertEqual(call_args.unknown_args, set())
+        self.assertEqual(call_args.unknown_kwargs, set())

--- a/tests/vulnerabilities/vulnerabilities_across_files_test.py
+++ b/tests/vulnerabilities/vulnerabilities_across_files_test.py
@@ -83,7 +83,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 Label: ~call_2 = ret_scrypt.encrypt('echo ' + param + ' >> ' + 'menu.txt', 'password')
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_builtin_with_user_defined_inner(self):
         vulnerabilities = self.run_analysis('examples/nested_functions_code/builtin_with_user_defined_inner.py')
@@ -117,7 +117,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_3 = ret_subprocess.call(foo, shell=True)
             This vulnerability is unknown due to:  Label: ~call_1 = ret_scrypt.encrypt(~call_2)
         """
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_sink_with_result_of_blackbox_nested(self):
         vulnerabilities = self.run_analysis('examples/nested_functions_code/sink_with_result_of_blackbox_nested.py')
@@ -203,7 +203,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
              > reaches line 18, sink "subprocess.call(":
                 ~call_3 = ret_subprocess.call(result, shell=True)
         """
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_sink_with_blackbox_inner(self):
         vulnerabilities = self.run_analysis('examples/nested_functions_code/sink_with_blackbox_inner.py')
@@ -284,7 +284,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
              > reaches line 18, sink "subprocess.call(":
                 ~call_1 = ret_subprocess.call(~call_2, shell=True)
         """
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_find_vulnerabilities_import_file_command_injection(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code_across_files/import_file_command_injection.py')

--- a/tests/vulnerabilities/vulnerabilities_base_test_case.py
+++ b/tests/vulnerabilities/vulnerabilities_base_test_case.py
@@ -8,3 +8,10 @@ class VulnerabilitiesBaseTestCase(BaseTestCase):
             [char for char in output if char.isalpha()] ==
             [char for char in expected_string if char.isalpha()]
         )
+
+    def assertAlphaEqual(self, output, expected_string):
+        self.assertEqual(
+            [char for char in output if char.isalpha()],
+            [char for char in expected_string if char.isalpha()]
+        )
+        return True

--- a/tests/vulnerabilities/vulnerabilities_test.py
+++ b/tests/vulnerabilities/vulnerabilities_test.py
@@ -168,7 +168,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_4 = ret_html.replace('{{ param }}', param)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_command_injection_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/command_injection.py')
@@ -186,7 +186,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_1 = ret_subprocess.call(command, shell=True)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_path_traversal_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/path_traversal.py')
@@ -224,7 +224,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_4 = ret_send_file(foo)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_ensure_saved_scope(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/ensure_saved_scope.py')
@@ -262,7 +262,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_4 = ret_send_file(image_name)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_path_traversal_sanitised_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/path_traversal_sanitised.py')
@@ -289,7 +289,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
             This vulnerability is sanitised by:  Label: ~call_2 = ret_image_name.replace('..', '')
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_path_traversal_sanitised_2_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/path_traversal_sanitised_2.py')
@@ -312,7 +312,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
             This vulnerability is potentially sanitised by:  Label: if '..' in image_name:
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_sql_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/sql/sqli.py')
@@ -332,7 +332,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_2 = ret_db.engine.execute(param)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_XSS_form_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/XSS_form.py')
@@ -354,7 +354,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_2 = ret_html1.replace('{{ data }}', data)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_XSS_url_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/XSS_url.py')
@@ -378,7 +378,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_3 = ret_html.replace('{{ param }}', param)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_XSS_no_vuln_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/XSS_no_vuln.py')
@@ -408,7 +408,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_4 = ret_html.replace('{{ param }}', param)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_XSS_sanitised_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/XSS_sanitised.py')
@@ -437,7 +437,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
             This vulnerability is sanitised by:  Label: ~call_2 = ret_Markup.escape(param)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_XSS_variable_assign_no_vuln_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/XSS_variable_assign_no_vuln.py')
@@ -467,7 +467,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_4 = ret_html.replace('{{ param }}', other_var)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
     def test_XSS_variable_multiple_assign_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/XSS_variable_multiple_assign.py')
@@ -497,7 +497,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
                 ~call_4 = ret_html.replace('{{ param }}', another_one)
         """
 
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
 
 class EngineDjangoTest(VulnerabilitiesBaseTestCase):
@@ -539,7 +539,7 @@ class EngineDjangoTest(VulnerabilitiesBaseTestCase):
              > reaches line 5, sink "render(":
                 ~call_1 = ret_render(request, 'templates/xss.html', 'param'param)
         """
-        self.assertTrue(self.string_compare_alpha(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION))
+        self.assertAlphaEqual(vulnerability_description, EXPECTED_VULNERABILITY_DESCRIPTION)
 
 
 class EngineEveryTest(VulnerabilitiesBaseTestCase):

--- a/tests/vulnerabilities/vulnerabilities_test.py
+++ b/tests/vulnerabilities/vulnerabilities_test.py
@@ -11,9 +11,13 @@ from pyt.usage import (
 )
 from pyt.vulnerabilities import (
     find_vulnerabilities,
-    trigger_definitions_parser,
     UImode,
     vulnerabilities
+)
+from pyt.vulnerabilities.trigger_definitions_parser import (
+    parse,
+    Sink,
+    Source,
 )
 from pyt.web_frameworks import (
     FrameworkAdaptor,
@@ -25,7 +29,7 @@ from pyt.web_frameworks import (
 
 class EngineTest(VulnerabilitiesBaseTestCase):
     def test_parse(self):
-        definitions = trigger_definitions_parser.parse(
+        definitions = parse(
             trigger_word_file=os.path.join(
                 os.getcwd(),
                 'pyt',
@@ -36,44 +40,31 @@ class EngineTest(VulnerabilitiesBaseTestCase):
 
         self.assert_length(definitions.sources, expected_length=1)
         self.assert_length(definitions.sinks, expected_length=3)
-        self.assert_length(definitions.sinks[0][1], expected_length=1)
-        self.assert_length(definitions.sinks[1][1], expected_length=3)
-
-    def test_parse_section(self):
-        list_ = list(trigger_definitions_parser.parse_section(iter(['get'])))
-        self.assert_length(list_, expected_length=1)
-        self.assertEqual(list_[0][0], 'get')
-        self.assertEqual(list_[0][1], list())
-
-        list_ = list(trigger_definitions_parser.parse_section(iter(['get', 'get -> a, b, c d s aq     a'])))
-        self.assert_length(list_, expected_length=2)
-        self.assertEqual(list_[0][0], 'get')
-        self.assertEqual(list_[1][0], 'get')
-        self.assertEqual(list_[1][1], ['a', 'b', 'c d s aq     a'])
-        self.assert_length(list_[1][1], expected_length=3)
+        self.assert_length(definitions.sinks[0].sanitisers, expected_length=1)
+        self.assert_length(definitions.sinks[1].sanitisers, expected_length=3)
 
     def test_label_contains(self):
         cfg_node = Node('label', None, line_number=None, path=None)
-        trigger_words = [('get', [])]
+        trigger_words = [Source('get')]
         list_ = list(vulnerabilities.label_contains(cfg_node, trigger_words))
         self.assert_length(list_, expected_length=0)
 
         cfg_node = Node('request.get("stefan")', None, line_number=None, path=None)
-        trigger_words = [('get', []), ('request', [])]
+        trigger_words = [Sink('request'), Source('get')]
         list_ = list(vulnerabilities.label_contains(cfg_node, trigger_words))
         self.assert_length(list_, expected_length=2)
 
         trigger_node_1 = list_[0]
         trigger_node_2 = list_[1]
-        self.assertEqual(trigger_node_1.trigger_word, 'get')
+        self.assertEqual(trigger_node_1.trigger_word, 'request')
         self.assertEqual(trigger_node_1.cfg_node, cfg_node)
-        self.assertEqual(trigger_node_2.trigger_word, 'request')
+        self.assertEqual(trigger_node_2.trigger_word, 'get')
         self.assertEqual(trigger_node_2.cfg_node, cfg_node)
 
         cfg_node = Node('request.get("stefan")', None, line_number=None, path=None)
-        trigger_words = [('get', []), ('get', [])]
+        trigger_words = [Source('get'), Source('get'), Sink('get(')]
         list_ = list(vulnerabilities.label_contains(cfg_node, trigger_words))
-        self.assert_length(list_, expected_length=2)
+        self.assert_length(list_, expected_length=3)
 
     def test_find_triggers(self):
         self.cfg_create_from_file('examples/vulnerable_code/XSS.py')
@@ -83,7 +74,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
         FrameworkAdaptor(cfg_list, [], [], is_flask_route_function)
 
         XSS1 = cfg_list[1]
-        trigger_words = [('get', [])]
+        trigger_words = [Source('get')]
 
         list_ = vulnerabilities.find_triggers(
             XSS1.nodes,
@@ -110,7 +101,8 @@ class EngineTest(VulnerabilitiesBaseTestCase):
         cfg = cfg_list[1]
 
         cfg_node = Node(None, None, line_number=None, path=None)
-        sinks_in_file = [vulnerabilities.TriggerNode('replace', ['escape'], cfg_node)]
+        sink = Sink.from_json('replace', {'sanitisers': ['escape']})
+        sinks_in_file = [vulnerabilities.TriggerNode(sink, cfg_node)]
 
         sanitiser_dict = vulnerabilities.build_sanitiser_node_dict(cfg, sinks_in_file)
         self.assert_length(sanitiser_dict, expected_length=1)


### PR DESCRIPTION
The aim of this is to reduce the number of false positives.

In the json trigger file you can specify a list of arg positions or
keywords which propagate or ignore taint.

So e.g there may be an execute function
where the first argument is raw SQL query text which is affected by
taint, but any other arguments are variables passed in to the prepared SQL
statement and (we assume) can be tainted user input without a problem.

To do this we can no longer just use the RHSVisitor to see which
variables are used by a sink. We need the results of each arg / kwarg
separately.

There is the added complication of *args and **kwargs where we need to
determine if a RHS variable could pass into a propagating arg / kwarg or not.
Probably the best way to understand it is to look at the added test cases.

#145