### PR TITLE
Import woes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 show_missing = True
 
 exclude_lines =
-    def valid_date
     def __repr__
     def __str__
     if __name__ == .__main__.:

--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -86,7 +86,7 @@ def main(command_line_args=sys.argv[1:]):  # noqa: C901
             directory = os.path.normpath(args.project_root)
         else:
             directory = os.path.dirname(path)
-        project_modules = get_modules(directory)
+        project_modules = get_modules(directory, prepend_module_root=args.prepend_module_root)
         local_modules = get_directory_modules(directory)
         tree = generate_ast(path)
 

--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -94,7 +94,8 @@ def main(command_line_args=sys.argv[1:]):  # noqa: C901
             tree,
             project_modules,
             local_modules,
-            path
+            path,
+            allow_local_directory_imports=args.allow_local_imports
         )
         cfg_list = [cfg]
 

--- a/pyt/cfg/expr_visitor.py
+++ b/pyt/cfg/expr_visitor.py
@@ -37,11 +37,13 @@ class ExprVisitor(StmtVisitor):
         project_modules,
         local_modules,
         filename,
-        module_definitions=None
+        module_definitions=None,
+        allow_local_directory_imports=True
     ):
         """Create an empty CFG."""
+        super().__init__(allow_local_directory_imports=allow_local_directory_imports)
         self.project_modules = project_modules
-        self.local_modules = local_modules
+        self.local_modules = local_modules if self._allow_local_modules else []
         self.filenames = [filename]
         self.blackbox_assignments = set()
         self.nodes = list()

--- a/pyt/cfg/make_cfg.py
+++ b/pyt/cfg/make_cfg.py
@@ -30,14 +30,16 @@ def make_cfg(
     project_modules,
     local_modules,
     filename,
-    module_definitions=None
+    module_definitions=None,
+    allow_local_directory_imports=True
 ):
     visitor = ExprVisitor(
         tree,
         project_modules,
         local_modules,
         filename,
-        module_definitions
+        module_definitions,
+        allow_local_directory_imports
     )
     return CFG(
         visitor.nodes,

--- a/pyt/cfg/stmt_visitor.py
+++ b/pyt/cfg/stmt_visitor.py
@@ -53,6 +53,9 @@ from .stmt_visitor_helper import (
 
 
 class StmtVisitor(ast.NodeVisitor):
+    def __init__(self, allow_local_directory_imports=True):
+        self._allow_local_modules = allow_local_directory_imports
+        super().__init__()
 
     def visit_Module(self, node):
         return self.stmt_star_handler(node.body)
@@ -753,7 +756,7 @@ class StmtVisitor(ast.NodeVisitor):
 
         # Analyse the file
         self.filenames.append(module_path)
-        self.local_modules = get_directory_modules(module_path)
+        self.local_modules = get_directory_modules(module_path) if self._allow_local_modules else []
         tree = generate_ast(module_path)
 
         # module[0] is None during e.g. "from . import foo", so we must str()

--- a/pyt/core/project_handler.py
+++ b/pyt/core/project_handler.py
@@ -31,7 +31,7 @@ def get_directory_modules(directory):
     return _local_modules
 
 
-def get_modules(path):
+def get_modules(path, prepend_module_root=True):
     """Return a list containing tuples of
     e.g. ('test_project.utils', 'example/test_project/utils.py')
     """
@@ -52,10 +52,20 @@ def get_modules(path):
                     '.'
                 )
                 directory = directory.replace('.', '', 1)
-                modules.append((
-                    '.'.join(p for p in (module_root, directory, _filename_to_module(filename)) if p),
-                    os.path.join(root, filename)
-                ))
+
+                module_name_parts = []
+                if prepend_module_root:
+                    module_name_parts.append(module_root)
+                if directory:
+                    module_name_parts.append(directory)
+
+                if filename == '__init__.py':
+                    path = root
+                else:
+                    module_name_parts.append(os.path.splitext(filename)[0])
+                    path = os.path.join(root, filename)
+
+                modules.append(('.'.join(module_name_parts), path))
 
     return modules
 
@@ -64,10 +74,3 @@ def _is_python_file(path):
     if os.path.splitext(path)[1] == '.py':
         return True
     return False
-
-
-def _filename_to_module(filename):
-    if filename == '__init__.py':
-        return ''
-    else:
-        return os.path.splitext(filename)[0]

--- a/pyt/core/project_handler.py
+++ b/pyt/core/project_handler.py
@@ -52,14 +52,10 @@ def get_modules(path):
                     '.'
                 )
                 directory = directory.replace('.', '', 1)
-                if directory:
-                    modules.append(
-                        ('.'.join((module_root, directory, filename.replace('.py', ''))), os.path.join(root, filename))
-                    )
-                else:
-                    modules.append(
-                        ('.'.join((module_root, filename.replace('.py', ''))), os.path.join(root, filename))
-                    )
+                modules.append((
+                    '.'.join(p for p in (module_root, directory, _filename_to_module(filename)) if p),
+                    os.path.join(root, filename)
+                ))
 
     return modules
 
@@ -68,3 +64,10 @@ def _is_python_file(path):
     if os.path.splitext(path)[1] == '.py':
         return True
     return False
+
+
+def _filename_to_module(filename):
+    if filename == '__init__.py':
+        return ''
+    else:
+        return os.path.splitext(filename)[0]

--- a/pyt/usage.py
+++ b/pyt/usage.py
@@ -101,6 +101,13 @@ def _add_optional_group(parser):
         default='',
         help='Separate files with commas'
     )
+    optional_group.add_argument(
+        '--dont-prepend-root',
+        help="In project root e.g. /app, imports are not prepended with app.*",
+        action='store_false',
+        default=True,
+        dest='prepend_module_root'
+    )
 
 
 def _add_print_group(parser):

--- a/pyt/usage.py
+++ b/pyt/usage.py
@@ -99,6 +99,14 @@ def _add_optional_group(parser):
         default=True,
         dest='prepend_module_root'
     )
+    optional_group.add_argument(
+        '--no-local-imports',
+        help='If set, absolute imports must be relative to the project root. '
+             'If not set, modules in the same directory can be imported just by their names.',
+        action='store_false',
+        default=True,
+        dest='allow_local_imports'
+    )
 
 
 def _add_print_group(parser):

--- a/pyt/usage.py
+++ b/pyt/usage.py
@@ -18,15 +18,6 @@ default_trigger_word_file = os.path.join(
 )
 
 
-def valid_date(s):
-    date_format = "%Y-%m-%d"
-    try:
-        return datetime.strptime(s, date_format).date()
-    except ValueError:
-        msg = "Not a valid date: '{0}'. Format: {1}".format(s, date_format)
-        raise argparse.ArgumentTypeError(msg)
-
-
 def _add_required_group(parser):
     required_group = parser.add_argument_group('required arguments')
     required_group.add_argument(

--- a/tests/core/project_handler_test.py
+++ b/tests/core/project_handler_test.py
@@ -32,7 +32,7 @@ class ProjectHandlerTest(unittest.TestCase):
         utils_path = os.path.join(project_folder, 'utils.py')
         exceptions_path = os.path.join(project_folder, 'exceptions.py')
         some_path = os.path.join(project_folder, folder, 'some.py')
-        __init__path = os.path.join(project_folder, folder, '__init__.py')
+        __init__path = os.path.join(project_folder, folder)
         indhold_path = os.path.join(project_folder, folder, directory, 'indhold.py')
 
         # relative_folder_name = '.' + folder
@@ -54,6 +54,32 @@ class ProjectHandlerTest(unittest.TestCase):
         self.assertIn(utils_tuple, modules)
         self.assertIn(exceptions_tuple, modules)
         self.assertIn(some_tuple, modules)
+        self.assertIn(__init__tuple, modules)
+        self.assertIn(indhold_tuple, modules)
+
+        self.assertEqual(len(modules), 6)
+
+    def test_get_modules_no_prepend_root(self):
+        project_folder = os.path.normpath(os.path.join('examples', 'test_project'))
+
+        folder = 'folder'
+        directory = 'directory'
+
+        modules = get_modules(project_folder, prepend_module_root=False)
+
+        app_path = os.path.join(project_folder, 'app.py')
+        __init__path = os.path.join(project_folder, folder)
+        indhold_path = os.path.join(project_folder, folder, directory, 'indhold.py')
+
+        app_name = 'app'
+        __init__name = folder
+        indhold_name = folder + '.' + directory + '.indhold'
+
+        app_tuple = (app_name, app_path)
+        __init__tuple = (__init__name, __init__path)
+        indhold_tuple = (indhold_name, indhold_path)
+
+        self.assertIn(app_tuple, modules)
         self.assertIn(__init__tuple, modules)
         self.assertIn(indhold_tuple, modules)
 

--- a/tests/core/project_handler_test.py
+++ b/tests/core/project_handler_test.py
@@ -32,6 +32,7 @@ class ProjectHandlerTest(unittest.TestCase):
         utils_path = os.path.join(project_folder, 'utils.py')
         exceptions_path = os.path.join(project_folder, 'exceptions.py')
         some_path = os.path.join(project_folder, folder, 'some.py')
+        __init__path = os.path.join(project_folder, folder, '__init__.py')
         indhold_path = os.path.join(project_folder, folder, directory, 'indhold.py')
 
         # relative_folder_name = '.' + folder
@@ -39,21 +40,24 @@ class ProjectHandlerTest(unittest.TestCase):
         utils_name = project_namespace + '.' + 'utils'
         exceptions_name = project_namespace + '.' + 'exceptions'
         some_name = project_namespace + '.' + folder + '.some'
+        __init__name = project_namespace + '.' + folder
         indhold_name = project_namespace + '.' + folder + '.' + directory + '.indhold'
 
         app_tuple = (app_name, app_path)
         utils_tuple = (utils_name, utils_path)
         exceptions_tuple = (exceptions_name, exceptions_path)
         some_tuple = (some_name, some_path)
+        __init__tuple = (__init__name, __init__path)
         indhold_tuple = (indhold_name, indhold_path)
 
         self.assertIn(app_tuple, modules)
         self.assertIn(utils_tuple, modules)
         self.assertIn(exceptions_tuple, modules)
         self.assertIn(some_tuple, modules)
+        self.assertIn(__init__tuple, modules)
         self.assertIn(indhold_tuple, modules)
 
-        self.assertEqual(len(modules), 5)
+        self.assertEqual(len(modules), 6)
 
     def test_get_modules_and_packages(self):
         project_folder = os.path.normpath(os.path.join('examples', 'test_project'))
@@ -104,4 +108,4 @@ class ProjectHandlerTest(unittest.TestCase):
         self.assertIn(some_tuple, modules)
         self.assertIn(indhold_tuple, modules)
 
-        self.assertEqual(len(modules), 7)
+        self.assertEqual(len(modules), 8)

--- a/tests/usage_test.py
+++ b/tests/usage_test.py
@@ -28,8 +28,8 @@ class UsageTest(BaseTestCase):
         EXPECTED = """usage: python -m pyt [-h] [-a ADAPTOR] [-pr PROJECT_ROOT]
                      [-b BASELINE_JSON_FILE] [-j] [-m BLACKBOX_MAPPING_FILE]
                      [-t TRIGGER_WORD_FILE] [-o OUTPUT_FILE] [--ignore-nosec]
-                     [-r] [-x EXCLUDED_PATHS] [--dont-prepend-root] [-trim]
-                     [-i]
+                     [-r] [-x EXCLUDED_PATHS] [--dont-prepend-root]
+                     [--no-local-imports] [-trim] [-i]
                      targets [targets ...]
 
 required arguments:
@@ -58,6 +58,9 @@ optional arguments:
                         Separate files with commas
   --dont-prepend-root   In project root e.g. /app, imports are not prepended
                         with app.*
+  --no-local-imports    If set, absolute imports must be relative to the
+                        project root. If not set, modules in the same
+                        directory can be imported just by their names.
 
 print arguments:
   -trim, --trim-reassigned-in
@@ -76,8 +79,8 @@ print arguments:
         EXPECTED = """usage: python -m pyt [-h] [-a ADAPTOR] [-pr PROJECT_ROOT]
                      [-b BASELINE_JSON_FILE] [-j] [-m BLACKBOX_MAPPING_FILE]
                      [-t TRIGGER_WORD_FILE] [-o OUTPUT_FILE] [--ignore-nosec]
-                     [-r] [-x EXCLUDED_PATHS] [--dont-prepend-root] [-trim]
-                     [-i]
+                     [-r] [-x EXCLUDED_PATHS] [--dont-prepend-root]
+                     [--no-local-imports] [-trim] [-i]
                      targets [targets ...]
 python -m pyt: error: the following arguments are required: targets\n"""
 

--- a/tests/usage_test.py
+++ b/tests/usage_test.py
@@ -28,7 +28,8 @@ class UsageTest(BaseTestCase):
         EXPECTED = """usage: python -m pyt [-h] [-a ADAPTOR] [-pr PROJECT_ROOT]
                      [-b BASELINE_JSON_FILE] [-j] [-m BLACKBOX_MAPPING_FILE]
                      [-t TRIGGER_WORD_FILE] [-o OUTPUT_FILE] [--ignore-nosec]
-                     [-r] [-x EXCLUDED_PATHS] [-trim] [-i]
+                     [-r] [-x EXCLUDED_PATHS] [--dont-prepend-root] [-trim]
+                     [-i]
                      targets [targets ...]
 
 required arguments:
@@ -55,6 +56,8 @@ optional arguments:
   -r, --recursive       find and process files in subdirectories
   -x EXCLUDED_PATHS, --exclude EXCLUDED_PATHS
                         Separate files with commas
+  --dont-prepend-root   In project root e.g. /app, imports are not prepended
+                        with app.*
 
 print arguments:
   -trim, --trim-reassigned-in
@@ -73,7 +76,8 @@ print arguments:
         EXPECTED = """usage: python -m pyt [-h] [-a ADAPTOR] [-pr PROJECT_ROOT]
                      [-b BASELINE_JSON_FILE] [-j] [-m BLACKBOX_MAPPING_FILE]
                      [-t TRIGGER_WORD_FILE] [-o OUTPUT_FILE] [--ignore-nosec]
-                     [-r] [-x EXCLUDED_PATHS] [-trim] [-i]
+                     [-r] [-x EXCLUDED_PATHS] [--dont-prepend-root] [-trim]
+                     [-i]
                      targets [targets ...]
 python -m pyt: error: the following arguments are required: targets\n"""
 


### PR DESCRIPTION
I have had some trouble with imports due to my project setup.

By adding 2 new flags, we can alter how pyt expects a project to be setup. I hope you don't think it makes things too complicated.

For a project with root in /app, currently pyt expects that all of the imports are of the form:

`from app.folder.module import thing`

But actually a project could not be expecting the module root to be prepended.

My projects use:

`from folder.module import thing`

I also had a problem where one of my directories had a file called flask.py.

Because of this, any imports of the package flask were causing pyt to import from the local file flask.py. In my project this caused a circular import and RecursionError which crashed pyt.

My projects always either use relative imports with `from .somewhere.else import ...` or import relative to the project root. They never import a local file just by the filename.