### PR TITLE
Cache of AST tree by module path

### DIFF
--- a/pyt/core/ast_helper.py
+++ b/pyt/core/ast_helper.py
@@ -4,6 +4,7 @@ Useful when working with the ast module."""
 import ast
 import os
 import subprocess
+from functools import lru_cache
 
 
 BLACK_LISTED_CALL_NAMES = ['self']
@@ -21,6 +22,7 @@ def _convert_to_3(path):  # pragma: no cover
         exit(1)
 
 
+@lru_cache()
 def generate_ast(path):
     """Generate an Abstract Syntax Tree using the ast module.
 


### PR DESCRIPTION
The dependency graph of a large Python app can be quite a mess.

Previously, we were regenerating the AST of files many times, as they were
imported by different modules.

Adding a simple LRU cache [path -> AST tree] sped up pyt on one of my
code bases by 5x.

We currently only mutate newly created artificial nodes, so we can store
one copy of each module's AST and expect it to be static.

We can make it even faster by setting `maxsize=None`, so there is no eviction
logic, but for now I think it's already an improvement.

An alternative could be to rewrite the code which deals with imports.