### PR TITLE
Yield, YieldFrom, AugAssign propagate taint

### DIFF
--- a/examples/example_inputs/generator_with_multiple_yields.py
+++ b/examples/example_inputs/generator_with_multiple_yields.py
@@ -1,0 +1,7 @@
+def foo():
+    a = 1
+    if a == 1:
+        yield 0
+    yield a
+
+foo()

--- a/examples/vulnerable_code/yield.py
+++ b/examples/vulnerable_code/yield.py
@@ -1,0 +1,21 @@
+import subprocess
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+def things_to_run():
+    yield "echo hello"
+    yield from request.get_json()["commands"]
+    yield "echo done"
+
+
+@app.route('/', methods=['POST'])
+def home():
+    script = "; ".join(things_to_run())
+    subprocess.call(script, shell=True)
+    return 'Executed'
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/pyt/cfg/expr_visitor.py
+++ b/pyt/cfg/expr_visitor.py
@@ -114,11 +114,10 @@ class ExprVisitor(StmtVisitor):
         label = LabelVisitor()
         label.visit(node)
 
-        try:
-            rhs_visitor = RHSVisitor()
-            rhs_visitor.visit(node.value)
-        except AttributeError:
-            rhs_visitor.result = 'EmptyYield'
+        if node.value is None:
+            rhs_visitor_result = []
+        else:
+            rhs_visitor_result = RHSVisitor.result_for_node(node.value)
 
         # Yield is a bit like augmented assignment to a return value
         this_function_name = self.function_return_stack[-1]
@@ -127,7 +126,7 @@ class ExprVisitor(StmtVisitor):
             LHS + ' += ' + label.result,
             LHS,
             node,
-            rhs_visitor.result + [LHS],
+            rhs_visitor_result + [LHS],
             path=self.filenames[-1])
         )
 

--- a/pyt/cfg/stmt_visitor.py
+++ b/pyt/cfg/stmt_visitor.py
@@ -244,12 +244,6 @@ class StmtVisitor(ast.NodeVisitor):
         label = LabelVisitor()
         label.visit(node)
 
-        try:
-            rhs_visitor = RHSVisitor()
-            rhs_visitor.visit(node.value)
-        except AttributeError:
-            rhs_visitor.result = 'EmptyReturn'
-
         this_function_name = self.function_return_stack[-1]
         LHS = 'ret_' + this_function_name
 
@@ -263,14 +257,17 @@ class StmtVisitor(ast.NodeVisitor):
                 path=self.filenames[-1]
             )
             return_value_of_call.connect(return_node)
-            self.nodes.append(return_node)
-            return return_node
+            return self.append_node(return_node)
+        elif node.value is not None:
+            rhs_visitor_result = RHSVisitor.result_for_node(node.value)
+        else:
+            rhs_visitor_result = []
 
         return self.append_node(ReturnNode(
             LHS + ' = ' + label.result,
             LHS,
             node,
-            rhs_visitor.result,
+            rhs_visitor_result,
             path=self.filenames[-1]
         ))
 

--- a/pyt/cfg/stmt_visitor.py
+++ b/pyt/cfg/stmt_visitor.py
@@ -499,11 +499,12 @@ class StmtVisitor(ast.NodeVisitor):
         rhs_visitor = RHSVisitor()
         rhs_visitor.visit(node.value)
 
+        lhs = extract_left_hand_side(node.target)
         return self.append_node(AssignmentNode(
             label.result,
-            extract_left_hand_side(node.target),
+            lhs,
             node,
-            rhs_visitor.result,
+            rhs_visitor.result + [lhs],
             path=self.filenames[-1]
         ))
 

--- a/pyt/core/README.rst
+++ b/pyt/core/README.rst
@@ -9,7 +9,7 @@ This directory contains miscellaneous code that is imported from different parts
 
 - `get_call_names`_ used in `vars_visitor.py`_ when visiting a Subscript, and `framework_helper.py`_ on function decorators in `is_flask_route_function`_
 
-- `get_call_names_as_string`_ used in `expr_visitor.py`_ to create ret_function_name as RHS and yield_function_name as LHS, and in stmt_visitor.py when connecting a function to a loop.
+- `get_call_names_as_string`_ used in `expr_visitor.py`_ to create ret_function_name as RHS and yld_function_name as LHS, and in stmt_visitor.py when connecting a function to a loop.
 
 - `Arguments`_ used in `expr_visitor.py`_ when processing the arguments of a user defined function and `framework_adaptor.py`_ to taint function definition arguments.
 

--- a/pyt/core/node_types.py
+++ b/pyt/core/node_types.py
@@ -285,3 +285,11 @@ class ReturnNode(AssignmentNode, ConnectToExitNode):
             line_number=ast_node.lineno,
             path=path
         )
+
+
+class YieldNode(AssignmentNode):
+    """CFG Node that represents a yield or yield from.
+
+    The presence of a YieldNode means that a function is a generator.
+    """
+    pass

--- a/pyt/vulnerabilities/vulnerability_helper.py
+++ b/pyt/vulnerabilities/vulnerability_helper.py
@@ -4,6 +4,8 @@ import json
 from enum import Enum
 from collections import namedtuple
 
+from ..core.node_types import YieldNode
+
 
 class VulnerabilityType(Enum):
     FALSE = 0
@@ -56,12 +58,19 @@ class Vulnerability():
 
         self.reassignment_nodes = reassignment_nodes
         self._remove_sink_from_secondary_nodes()
+        self._remove_non_propagating_yields()
 
     def _remove_sink_from_secondary_nodes(self):
         try:
             self.reassignment_nodes.remove(self.sink)
         except ValueError:  # pragma: no cover
             pass
+
+    def _remove_non_propagating_yields(self):
+        """Remove yield with no variables e.g. `yield 123` and plain `yield` from vulnerability."""
+        for node in list(self.reassignment_nodes):
+            if isinstance(node, YieldNode) and len(node.right_hand_side_variables) == 1:
+                self.reassignment_nodes.remove(node)
 
     def __str__(self):
         """Pretty printing of a vulnerability."""

--- a/tests/cfg/cfg_test.py
+++ b/tests/cfg/cfg_test.py
@@ -820,6 +820,14 @@ class CFGAssignmentMultiTest(CFGBaseTestCase):
             [('a', ['d']), ('b', ['d']), ('c', ['e'])],
         )
 
+    def test_augmented_assignment(self):
+        self.cfg_create_from_ast(ast.parse('a+=f(b,c)'))
+
+        (node,) = self.cfg.nodes[1:-1]
+        self.assertEqual(node.label, 'a += f(b, c)')
+        self.assertEqual(node.left_hand_side, 'a')
+        self.assertEqual(node.right_hand_side_variables, ['b', 'c', 'a'])
+
 
 class CFGComprehensionTest(CFGBaseTestCase):
     def test_nodes(self):

--- a/tests/cfg/cfg_test.py
+++ b/tests/cfg/cfg_test.py
@@ -995,6 +995,42 @@ class CFGFunctionNodeTest(CFGBaseTestCase):
                           (call_foo, exit_foo),
                           (_exit, call_foo)])
 
+    def test_generator_multiple_yield(self):
+        path = 'examples/example_inputs/generator_with_multiple_yields.py'
+        self.cfg_create_from_file(path)
+
+        self.assert_length(self.cfg.nodes, expected_length=9)
+
+        entry = 0
+        entry_foo = 1
+        a = 2
+        _if = 3
+        yld_if = 4
+        yld = 5
+        exit_foo = 6
+        call_foo = 7
+        _exit = 8
+
+        self.assertInCfg([
+            (entry_foo, entry),
+            (a, entry_foo),
+            (_if, a),
+            (yld_if, _if),
+            (yld, _if),
+            (yld, yld_if),  # Different from return
+            (exit_foo, yld),
+            (call_foo, exit_foo),
+            (_exit, call_foo)
+        ])
+
+        yld_if_node = self.cfg.nodes[yld_if]
+        self.assertEqual(yld_if_node.left_hand_side, 'yld_foo')
+        self.assertEqual(yld_if_node.right_hand_side_variables, ['yld_foo'])
+        yld_node = self.cfg.nodes[yld]
+        self.assertEqual(yld_node.left_hand_side, 'yld_foo')
+        self.assertEqual(yld_node.right_hand_side_variables, ['a', 'yld_foo'])
+        self.assertEqual(self.cfg.nodes[call_foo].right_hand_side_variables, ['yld_foo'])
+
     def test_blackbox_call_after_if(self):
         path = 'examples/vulnerable_code/blackbox_call_after_if.py'
         self.cfg_create_from_file(path)

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -99,11 +99,11 @@ class DiscoverFilesTest(BaseTestCase):
         excluded_files = ""
 
         included_files = discover_files(targets, excluded_files, True)
-        self.assertEqual(len(included_files), 30)
+        self.assertEqual(len(included_files), 31)
 
     def test_targets_with_recursive_and_excluded(self):
         targets = ["examples/vulnerable_code/"]
         excluded_files = "inter_command_injection.py"
 
         included_files = discover_files(targets, excluded_files, True)
-        self.assertEqual(len(included_files), 29)
+        self.assertEqual(len(included_files), 30)


### PR DESCRIPTION
Previously `+=` only propagated taint of the last assigment. Now, the original variable is added to `right_hand_side_variables`.

Yield and YieldFrom are treated a bit like augmented assignment, giving the function a final return variable `yld_` a bit like `ret_`. Really it's a generator function, but we can treat it as a normal function. So anything yielded propagates taint to the overall "return" value of the function.