### PR TITLE
Exit code 1 if unsanitised vulnerabilities found

### DIFF
--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -22,6 +22,7 @@ from .vulnerabilities import (
     get_vulnerabilities_not_in_baseline,
     UImode
 )
+from .vulnerabilities.vulnerability_helper import SanitisedVulnerability
 from .web_frameworks import (
     FrameworkAdaptor,
     is_django_view_function,
@@ -136,6 +137,10 @@ def main(command_line_args=sys.argv[1:]):  # noqa: C901
         json.report(vulnerabilities, args.output_file)
     else:
         text.report(vulnerabilities, args.output_file)
+
+    has_unsanitized_vulnerabilities = any(not isinstance(v, SanitisedVulnerability) for v in vulnerabilities)
+    if has_unsanitized_vulnerabilities:
+        sys.exit(1)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[],
     entry_points={
         'console_scripts': [
-            'pyt = pyt:main'
+            'pyt = pyt.__main__:main'
         ]
     }
 )

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -16,15 +16,36 @@ class MainTest(BaseTestCase):
 
         mock_discover_files.return_value = [example_file]
         mock_parse_args.return_value = mock.Mock(
-            autospec=True,
             project_root=None,
             baseline=None,
             json=None,
             output_file=output_file
         )
-        main([
-            'parse_args is mocked'
-        ])
+        with self.assertRaises(SystemExit):
+            main(['parse_args is mocked'])
+        assert mock_text.report.call_count == 1
+        mock_text.report.assert_called_with(
+            mock_find_vulnerabilities.return_value,
+            mock_parse_args.return_value.output_file
+        )
+
+    @mock.patch('pyt.__main__.discover_files')
+    @mock.patch('pyt.__main__.parse_args')
+    @mock.patch('pyt.__main__.find_vulnerabilities')
+    @mock.patch('pyt.__main__.text')
+    def test_no_vulns_found(self, mock_text, mock_find_vulnerabilities, mock_parse_args, mock_discover_files):
+        mock_find_vulnerabilities.return_value = []
+        example_file = 'examples/vulnerable_code/inter_command_injection.py'
+        output_file = 'mocked_outfile'
+
+        mock_discover_files.return_value = [example_file]
+        mock_parse_args.return_value = mock.Mock(
+            project_root=None,
+            baseline=None,
+            json=None,
+            output_file=output_file
+        )
+        main(['parse_args is mocked'])  # No SystemExit
         assert mock_text.report.call_count == 1
         mock_text.report.assert_called_with(
             mock_find_vulnerabilities.return_value,
@@ -42,15 +63,13 @@ class MainTest(BaseTestCase):
 
         mock_discover_files.return_value = [example_file]
         mock_parse_args.return_value = mock.Mock(
-            autospec=True,
             project_root=None,
             baseline=None,
             json=True,
             output_file=output_file
         )
-        main([
-            'parse_args is mocked'
-        ])
+        with self.assertRaises(SystemExit):
+            main(['parse_args is mocked'])
         assert mock_json.report.call_count == 1
         mock_json.report.assert_called_with(
             mock_find_vulnerabilities.return_value,

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -26,12 +26,10 @@ class MainTest(BaseTestCase):
             'parse_args is mocked'
         ])
         assert mock_text.report.call_count == 1
-        # This with: makes no sense
-        with self.assertRaises(AssertionError):
-            assert mock_text.report.assert_called_with(
-                mock_find_vulnerabilities.return_value,
-                mock_parse_args.return_value.output_file
-            )
+        mock_text.report.assert_called_with(
+            mock_find_vulnerabilities.return_value,
+            mock_parse_args.return_value.output_file
+        )
 
     @mock.patch('pyt.__main__.discover_files')
     @mock.patch('pyt.__main__.parse_args')
@@ -54,12 +52,10 @@ class MainTest(BaseTestCase):
             'parse_args is mocked'
         ])
         assert mock_json.report.call_count == 1
-        # This with: makes no sense
-        with self.assertRaises(AssertionError):
-            assert mock_json.report.assert_called_with(
-                mock_find_vulnerabilities.return_value,
-                mock_parse_args.return_value.output_file
-            )
+        mock_json.report.assert_called_with(
+            mock_find_vulnerabilities.return_value,
+            mock_parse_args.return_value.output_file
+        )
 
 
 class DiscoverFilesTest(BaseTestCase):


### PR DESCRIPTION
Not sure if you want this, but having a non-zero exit code if there are vulnerabilities would help with using pyt in an automated system like CI.