### PR TITLE
mock is included in unittest since Python 3.3

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from .base_test_case import BaseTestCase
 from pyt.__main__ import discover_files, main

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist = py36,cover,lint
 
 [testenv]
-deps = mock
 commands =
     python -m tests
 
@@ -10,7 +9,6 @@ commands =
 whitelist_externals = coverage
 deps =
     coverage>=4.0,<4.4
-    mock
 commands =
     coverage erase
     coverage run tests


### PR DESCRIPTION
https://docs.python.org/3/library/unittest.mock.html

"Pyt runs on python 3.6+":
https://github.com/python-security/pyt/commit/609acd6ca7e3800f21e82d5e3736e8112a91b49c#r29924039