### PR TITLE
Deterministic file loading and vulnerability order

### DIFF
--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -79,7 +79,7 @@ def main(command_line_args=sys.argv[1:]):  # noqa: C901
 
     nosec_lines = defaultdict(set)
 
-    for path in files:
+    for path in sorted(files):
         if not args.ignore_nosec:
             nosec_lines[path] = retrieve_nosec_lines(path)
 

--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -79,15 +79,18 @@ def main(command_line_args=sys.argv[1:]):  # noqa: C901
 
     nosec_lines = defaultdict(set)
 
+    if args.project_root:
+        directory = os.path.normpath(args.project_root)
+        project_modules = get_modules(directory, prepend_module_root=args.prepend_module_root)
+
     for path in sorted(files):
         if not args.ignore_nosec:
             nosec_lines[path] = retrieve_nosec_lines(path)
 
-        if args.project_root:
-            directory = os.path.normpath(args.project_root)
-        else:
+        if not args.project_root:
             directory = os.path.dirname(path)
-        project_modules = get_modules(directory, prepend_module_root=args.prepend_module_root)
+            project_modules = get_modules(directory, prepend_module_root=args.prepend_module_root)
+
         local_modules = get_directory_modules(directory)
         tree = generate_ast(path)
 


### PR DESCRIPTION
`os.walk` is not deterministic (though often on the same computer it will
walk in the same order).

This means that the vulnerabilities can appear in different orders, making it hard to compare output.

Process files in alphabetical order.

I do need to look more deeply into how the import system works because I think there are some other non-determinism problems which can result in vulnerabilities not being found but I haven't figured it out yet.