### PR TITLE
Chained function calls separated into multiple assignments

### DIFF
--- a/pyt/core/ast_helper.py
+++ b/pyt/core/ast_helper.py
@@ -6,7 +6,7 @@ import os
 import subprocess
 from functools import lru_cache
 
-from .transformer import AsyncTransformer
+from .transformer import PytTransformer
 
 
 BLACK_LISTED_CALL_NAMES = ['self']
@@ -35,7 +35,7 @@ def generate_ast(path):
         with open(path, 'r') as f:
             try:
                 tree = ast.parse(f.read())
-                return AsyncTransformer().visit(tree)
+                return PytTransformer().visit(tree)
             except SyntaxError:  # pragma: no cover
                 global recursive
                 if not recursive:

--- a/pyt/core/transformer.py
+++ b/pyt/core/transformer.py
@@ -1,7 +1,7 @@
 import ast
 
 
-class AsyncTransformer(ast.NodeTransformer):
+class AsyncTransformer():
     """Converts all async nodes into their synchronous counterparts."""
 
     def visit_Await(self, node):
@@ -16,3 +16,53 @@ class AsyncTransformer(ast.NodeTransformer):
 
     def visit_AsyncWith(self, node):
         return self.visit(ast.With(**node.__dict__))
+
+
+class ChainedFunctionTransformer():
+    def visit_chain(self, node, depth=1):
+        if (
+            isinstance(node.value, ast.Call) and
+            isinstance(node.value.func, ast.Attribute) and
+            isinstance(node.value.func.value, ast.Call)
+        ):
+            # Node is assignment or return with value like `b.c().d()`
+            call_node = node.value
+            # If we want to handle nested functions in future, depth needs fixing
+            temp_var_id = '__chain_tmp_{}'.format(depth)
+            # AST tree is from right to left, so d() is the outer Call and b.c() is the inner Call
+            unvisited_inner_call = ast.Assign(
+                targets=[ast.Name(id=temp_var_id, ctx=ast.Store())],
+                value=call_node.func.value,
+            )
+            ast.copy_location(unvisited_inner_call, node)
+            inner_calls = self.visit_chain(unvisited_inner_call, depth + 1)
+            for inner_call_node in inner_calls:
+                ast.copy_location(inner_call_node, node)
+            outer_call = self.generic_visit(type(node)(
+                value=ast.Call(
+                    func=ast.Attribute(
+                        value=ast.Name(id=temp_var_id, ctx=ast.Load()),
+                        attr=call_node.func.attr,
+                        ctx=ast.Load(),
+                    ),
+                    args=call_node.args,
+                    keywords=call_node.keywords,
+                ),
+                **{field: value for field, value in ast.iter_fields(node) if field != 'value'}  # e.g. targets
+            ))
+            ast.copy_location(outer_call, node)
+            ast.copy_location(outer_call.value, node)
+            ast.copy_location(outer_call.value.func, node)
+            return [*inner_calls, outer_call]
+        else:
+            return [self.generic_visit(node)]
+
+    def visit_Assign(self, node):
+        return self.visit_chain(node)
+
+    def visit_Return(self, node):
+        return self.visit_chain(node)
+
+
+class PytTransformer(AsyncTransformer, ChainedFunctionTransformer, ast.NodeTransformer):
+    pass

--- a/tests/base_test_case.py
+++ b/tests/base_test_case.py
@@ -4,6 +4,7 @@ import unittest
 from pyt.cfg import make_cfg
 from pyt.core.ast_helper import generate_ast
 from pyt.core.module_definitions import project_definitions
+from pyt.core.transformer import PytTransformer
 
 
 class BaseTestCase(unittest.TestCase):
@@ -36,7 +37,7 @@ class BaseTestCase(unittest.TestCase):
     ):
         project_definitions.clear()
         self.cfg = make_cfg(
-            ast_tree,
+            PytTransformer().visit(ast_tree),
             project_modules,
             local_modules,
             filename='?'

--- a/tests/vulnerabilities/vulnerabilities_test.py
+++ b/tests/vulnerabilities/vulnerabilities_test.py
@@ -282,7 +282,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
 
     def test_sql_result(self):
         vulnerabilities = self.run_analysis('examples/vulnerable_code/sql/sqli.py')
-        self.assert_length(vulnerabilities, expected_length=2)
+        self.assert_length(vulnerabilities, expected_length=3)
         vulnerability_description = str(vulnerabilities[0])
         EXPECTED_VULNERABILITY_DESCRIPTION = """
             File: examples/vulnerable_code/sql/sqli.py


### PR DESCRIPTION
Take the example from examples/vulnerable_code/sql/sqli.py:

```python
result = session.query(User).filter("username={}".format(TAINT))
```

The `filter` function is marked as a sink. However, previously this did not get marked as a vulnerability. The call label used to be `session.query`, ignoring the filter function.

Now, when the file is read, it is transformed into 2 lines:

```python
__chain_tmp_1 = session.query(User)
result = __chain_tmp_1.filter("username={}".format(TAINT))
```

 before converting to a CFG. The vulnerability is now found.

We don't find everything here: just ordinary assignments and return statements. We can't just transform all Call nodes here since Call nodes can appear in many different scenarios e.g. comprehensions, bare function calls. Because of this, it may be worth thinking about how to do this via the CFG everywhere function calls are chained.