### PR TITLE
 Recursive function calls shouldn't raise RecursionError

### DIFF
--- a/examples/vulnerable_code/recursive.py
+++ b/examples/vulnerable_code/recursive.py
@@ -1,0 +1,32 @@
+from flask import Flask, request
+
+app = Flask(__name__)
+
+
+def recur_without_any_propagation(x):
+    if len(x) < 20:
+        return recur_without_any_propagation("a" * 24)
+    return "Done"
+
+
+def recur_no_propagation_false_positive(x):
+    if len(x) < 20:
+        return recur_no_propagation_false_positive(x + "!")
+    return "Done"
+
+
+def recur_with_propagation(x):
+    if len(x) < 20:
+        return recur_with_propagation(x + "!")
+    return x
+
+
+@app.route('/recursive')
+def route():
+    param = request.args.get('param', 'not set')
+    repeated_completely_untainted = recur_without_any_propagation(param)
+    app.db.execute(repeated_completely_untainted)
+    repeated_untainted = recur_no_propagation_false_positive(param)
+    app.db.execute(repeated_untainted)
+    repeated_tainted = recur_with_propagation(param)
+    app.db.execute(repeated_tainted)

--- a/pyt/__main__.py
+++ b/pyt/__main__.py
@@ -125,7 +125,9 @@ def main(command_line_args=sys.argv[1:]):  # noqa: C901
         )
 
     initialize_constraint_table(cfg_list)
+    log.info("Analysing")
     analyse(cfg_list)
+    log.info("Finding vulnerabilities")
     vulnerabilities = find_vulnerabilities(
         cfg_list,
         args.blackbox_mapping_file,

--- a/pyt/web_frameworks/framework_adaptor.py
+++ b/pyt/web_frameworks/framework_adaptor.py
@@ -1,6 +1,7 @@
 """A generic framework adaptor that leaves route criteria to the caller."""
 
 import ast
+import logging
 
 from ..cfg import make_cfg
 from ..core.ast_helper import Arguments
@@ -9,6 +10,8 @@ from ..core.node_types import (
     AssignmentNode,
     TaintedNode
 )
+
+log = logging.getLogger(__name__)
 
 
 class FrameworkAdaptor():
@@ -31,6 +34,7 @@ class FrameworkAdaptor():
 
     def get_func_cfg_with_tainted_args(self, definition):
         """Build a function cfg and return it, with all arguments tainted."""
+        log.debug("Getting CFG for %s", definition.name)
         func_cfg = make_cfg(
             definition.node,
             self.project_modules,

--- a/tests/cfg/cfg_test.py
+++ b/tests/cfg/cfg_test.py
@@ -3,6 +3,7 @@ import ast
 from .cfg_base_test_case import CFGBaseTestCase
 
 from pyt.core.node_types import (
+    BBorBInode,
     EntryOrExitNode,
     Node
 )
@@ -1388,6 +1389,13 @@ class CFGFunctionNodeTest(CFGBaseTestCase):
     def test_call_on_call(self):
         path = 'examples/example_inputs/call_on_call.py'
         self.cfg_create_from_file(path)
+
+    def test_recursive_function(self):
+        path = 'examples/example_inputs/recursive.py'
+        self.cfg_create_from_file(path)
+        recursive_call = self.cfg.nodes[7]
+        assert recursive_call.label == '~call_3 = ret_rec(wat)'
+        assert isinstance(recursive_call, BBorBInode)  # Not RestoreNode
 
 
 class CFGCallWithAttributeTest(CFGBaseTestCase):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -108,11 +108,11 @@ class DiscoverFilesTest(BaseTestCase):
         excluded_files = ""
 
         included_files = discover_files(targets, excluded_files, True)
-        self.assertEqual(len(included_files), 31)
+        self.assertEqual(len(included_files), 32)
 
     def test_targets_with_recursive_and_excluded(self):
         targets = ["examples/vulnerable_code/"]
         excluded_files = "inter_command_injection.py"
 
         included_files = discover_files(targets, excluded_files, True)
-        self.assertEqual(len(included_files), 30)
+        self.assertEqual(len(included_files), 31)

--- a/tests/vulnerabilities/vulnerabilities_test.py
+++ b/tests/vulnerabilities/vulnerabilities_test.py
@@ -465,6 +465,11 @@ class EngineTest(VulnerabilitiesBaseTestCase):
         assert_vulnerable('result = repr(str("%s" % TAINT.lower().upper()))')
         assert_vulnerable('result = repr(str("{}".format(TAINT.lower())))')
 
+    def test_recursion(self):
+        # Really this file only has one vulnerability, but for now it's safer to keep the false positive.
+        vulnerabilities = self.run_analysis('examples/vulnerable_code/recursive.py')
+        self.assert_length(vulnerabilities, expected_length=2)
+
 
 class EngineDjangoTest(VulnerabilitiesBaseTestCase):
     def run_analysis(self, path):


### PR DESCRIPTION
Store a stack of definitions.

If you revisit a function, treat it as a blackbox.

The non-recursive return values should still propagate.