### PR TITLE
Better handling of IfExp (ternary)

### DIFF
--- a/examples/example_inputs/ternary.py
+++ b/examples/example_inputs/ternary.py
@@ -1,0 +1,9 @@
+result = (
+    "abc"
+    if t.u == v.w else
+    "def"
+    if x else
+    y  # This is the only RHS variable which taints result
+    if func(z if 1 + 1 == 2 else z) else
+    "ghi"
+)

--- a/pyt/helper_visitors/label_visitor.py
+++ b/pyt/helper_visitors/label_visitor.py
@@ -324,3 +324,12 @@ class LabelVisitor(ast.NodeVisitor):
     def visit_Starred(self, node):
         self.result += '*'
         self.visit(node.value)
+
+    def visit_IfExp(self, node):
+        self.result += '('
+        self.visit(node.test)
+        self.result += ') ? ('
+        self.visit(node.body)
+        self.result += ') : ('
+        self.visit(node.orelse)
+        self.result += ')'

--- a/pyt/helper_visitors/right_hand_side_visitor.py
+++ b/pyt/helper_visitors/right_hand_side_visitor.py
@@ -22,6 +22,11 @@ class RHSVisitor(ast.NodeVisitor):
             for keyword in node.keywords:
                 self.visit(keyword)
 
+    def visit_IfExp(self, node):
+        # The test doesn't taint the assignment
+        self.visit(node.body)
+        self.visit(node.orelse)
+
     @classmethod
     def result_for_node(cls, node):
         visitor = cls()

--- a/tests/cfg/cfg_test.py
+++ b/tests/cfg/cfg_test.py
@@ -580,6 +580,39 @@ class CFGIfTest(CFGBaseTestCase):
             (_exit, _if)
         ])
 
+    def test_ternary_ifexp(self):
+        self.cfg_create_from_file('examples/example_inputs/ternary.py')
+
+        # entry = 0
+        tmp_if_1 = 1
+        # tmp_if_inner = 2
+        call = 3
+        # tmp_if_call = 4
+        actual_if_exp = 5
+        exit = 6
+
+        self.assert_length(self.cfg.nodes, expected_length=exit + 1)
+        self.assertInCfg([
+            (i + 1, i) for i in range(exit)
+        ])
+
+        self.assertCountEqual(
+            self.cfg.nodes[actual_if_exp].right_hand_side_variables,
+            ['y'],
+            "The variables in the test expressions shouldn't appear as RHS variables"
+        )
+
+        self.assertCountEqual(
+            self.cfg.nodes[tmp_if_1].right_hand_side_variables,
+            ['t', 'v'],
+        )
+
+        self.assertIn(
+            'ret_func(',
+            self.cfg.nodes[call].label,
+            "Function calls inside the test expressions should still appear in the CFG",
+        )
+
 
 class CFGWhileTest(CFGBaseTestCase):
 

--- a/tests/core/transformer_test.py
+++ b/tests/core/transformer_test.py
@@ -52,3 +52,19 @@ class TransformerTest(unittest.TestCase):
 
         transformed = PytTransformer().visit(chained_tree)
         self.assertEqual(ast.dump(transformed), ast.dump(separated_tree))
+
+    def test_if_exp(self):
+        complex_if_exp_tree = ast.parse("\n".join([
+            "def a():",
+            "   b = c if d.e(f) else g if h else i if j.k(l) else m",
+        ]))
+
+        separated_tree = ast.parse("\n".join([
+            "def a():",
+            "   __if_exp_0 = d.e(f)",
+            "   __if_exp_1 = j.k(l)",
+            "   b = c if __if_exp_0 else g if h else i if __if_exp_1 else m",
+        ]))
+
+        transformed = PytTransformer().visit(complex_if_exp_tree)
+        self.assertEqual(ast.dump(transformed), ast.dump(separated_tree))

--- a/tests/helper_visitors/label_visitor_test.py
+++ b/tests/helper_visitors/label_visitor_test.py
@@ -83,3 +83,7 @@ class LabelVisitorTest(LabelVisitorTestCase):
     def test_starred(self):
         label = self.perform_labeling_on_expression('[a, *b] = *c, d')
         self.assertEqual(label.result, '[a, *b] = (*c, d)')
+
+    def test_if_exp(self):
+        label = self.perform_labeling_on_expression('a = b if c else d')
+        self.assertEqual(label.result, 'a = (c) ? (b) : (d)')


### PR DESCRIPTION
Reduces false positives.

As an example:

`result = "a" if TAINT else "c"`

In AST, the assignment value is `IfExp(test=TAINT, body="a", orelse="c")`.

Even though `TAINT` is inside the assignment of `result`, it can't
actually taint `result` as it is part of the boolean test expression.

Previously, `result` would have been tainted, which was a false
positive.

We don't want to completely ignore the test though in case it contains a
sink function.

Therefore, if the test contains expressions we transform it as so:

`result = "a" if b(c) + 2 else "d"`

to the multi line:

```python
__if_exp_0 = b(c) + 2
result = "a" if __if_exp_0 else "d"
```

This way if `b` is a sink and `c` is tainted we see a vulnerability, but
even if `c` is tainted we don't taint `result`.