### PR TITLE
list is tainted by calling list.append(TAINT)

### DIFF
--- a/examples/vulnerable_code/list_append.py
+++ b/examples/vulnerable_code/list_append.py
@@ -1,0 +1,13 @@
+import os
+
+from flask import request
+
+
+def func():
+    TAINT = request.args.get("TAINT")
+
+    cmd = []
+    cmd.append("echo")
+    cmd.append(TAINT)
+
+    os.system(" ".join(cmd))

--- a/pyt/cfg/expr_visitor_helper.py
+++ b/pyt/cfg/expr_visitor_helper.py
@@ -31,6 +31,13 @@ BUILTINS = (
     'flash',
     'jsonify'
 )
+MUTATORS = (  # list.append(x) taints list if x is tainted
+    'add',
+    'append',
+    'extend',
+    'insert',
+    'update',
+)
 
 
 def return_connection_handler(nodes, exit_node):

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -108,11 +108,11 @@ class DiscoverFilesTest(BaseTestCase):
         excluded_files = ""
 
         included_files = discover_files(targets, excluded_files, True)
-        self.assertEqual(len(included_files), 32)
+        self.assertEqual(len(included_files), 33)
 
     def test_targets_with_recursive_and_excluded(self):
         targets = ["examples/vulnerable_code/"]
         excluded_files = "inter_command_injection.py"
 
         included_files = discover_files(targets, excluded_files, True)
-        self.assertEqual(len(included_files), 31)
+        self.assertEqual(len(included_files), 32)

--- a/tests/vulnerabilities/vulnerabilities_test.py
+++ b/tests/vulnerabilities/vulnerabilities_test.py
@@ -110,12 +110,17 @@ class EngineTest(VulnerabilitiesBaseTestCase):
 
         self.assertEqual(sanitiser_dict['escape'][0], cfg.nodes[3])
 
-    def run_analysis(self, path=None):
+    def run_analysis(
+        self,
+        path=None,
+        adaptor_function=is_flask_route_function,
+        trigger_file=default_trigger_word_file,
+    ):
         if path:
             self.cfg_create_from_file(path)
         cfg_list = [self.cfg]
 
-        FrameworkAdaptor(cfg_list, [], [], is_flask_route_function)
+        FrameworkAdaptor(cfg_list, [], [], adaptor_function)
         initialize_constraint_table(cfg_list)
 
         analyse(cfg_list)
@@ -123,7 +128,7 @@ class EngineTest(VulnerabilitiesBaseTestCase):
         return find_vulnerabilities(
             cfg_list,
             default_blackbox_mapping_file,
-            default_trigger_word_file
+            trigger_file,
         )
 
     def test_find_vulnerabilities_assign_other_var(self):
@@ -469,6 +474,13 @@ class EngineTest(VulnerabilitiesBaseTestCase):
         # Really this file only has one vulnerability, but for now it's safer to keep the false positive.
         vulnerabilities = self.run_analysis('examples/vulnerable_code/recursive.py')
         self.assert_length(vulnerabilities, expected_length=2)
+
+    def test_list_append_taints_list(self):
+        vulnerabilities = self.run_analysis(
+            'examples/vulnerable_code/list_append.py',
+            adaptor_function=is_function,
+        )
+        self.assert_length(vulnerabilities, expected_length=1)
 
 
 class EngineDjangoTest(VulnerabilitiesBaseTestCase):


### PR DESCRIPTION
Taint is propagated by:

```
list += [TAINT]
list = list + TAINT
```

but with lists we often use a function to mutate the list:

```
list = []
list.append(TAINT)
list.insert(0, TAINT)
list.extend(TAINT)
```

Previously this didn't taint `list` so we had FALSE NEGATIVES.

Now `list.append(TAINT)` is treated like augmented assignment, so list
will be tainted.

`list += list.append(TAINT)`

Of course this wouldn't work as real code since `append` returns `None`
but it is how you can think about this function which mutates `list`.

The same goes for `set.add()`, `list.extend()`, `list.insert()`,
`dict.update()`, although we aren't actually doing type checking, just
looking at the name of the method.