### PR TITLE
128: Allow the user to cancel interactive mode

### DIFF
--- a/pyt/vulnerabilities/vulnerabilities.py
+++ b/pyt/vulnerabilities/vulnerabilities.py
@@ -336,11 +336,15 @@ def how_vulnerable(
                 return VulnerabilityType.FALSE
             elif interactive:
                 user_says = input(
-                    'Is the return value of {} with tainted argument "{}" vulnerable? (Y/n)'.format(
+                    'Is the return value of {} with tainted argument "{}" vulnerable? ([Y]es/[N]o/[S]top)'.format(
                         current_node.label,
                         chain[i - 1].left_hand_side
                     )
                 ).lower()
+                if user_says.startswith('s'):
+                    interactive = False
+                    vuln_deets['unknown_assignment'] = current_node
+                    return VulnerabilityType.UNKNOWN
                 if user_says.startswith('n'):
                     blackbox_mapping['does_not_propagate'].append(current_node.func_name)
                     return VulnerabilityType.FALSE


### PR DESCRIPTION
This should resolve #128. The change is so straight forward and any potential tests would be awkward, so I'm not sure we want to include specific tests for this (there were none before for interactive mode anyway). 

I'm open to suggestions though. 

You can manually test this change by using this sample code:
```python
import scrypt


image_name = request.args.get('image_name')
if not image_name:
    image_name = 'foo'
foo = scrypt.outer(image_name) # Any call after ControlFlowNode caused the problem
foo = scrypt.hash(foo, 'salt')
foo = scrypt.encrypt(os.urandom(datalength), foo)
send_file(foo)
```

Then `python -m pyt sample.py -m bb.txt -i`. You can see how it does as many as you want until you answer `s`.