### PR TITLE
Document python version to use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,8 @@ Example usage and output:
 Install
 =======
 
+Before continuing, make sure you have python3.6 or 3.7 installed.
+
 .. code-block:: python
 
 	pip install python-taint


### PR DESCRIPTION
It wasn't clear to me getting started that having python3.6 or 3.7 was essential.  This just adds a line to the readme describing that.