### PR TITLE
adding eval, exec sinks

### DIFF
--- a/pyt/vulnerability_definitions/all_trigger_words.pyt
+++ b/pyt/vulnerability_definitions/all_trigger_words.pyt
@@ -32,6 +32,8 @@
         },
         "commands.getoutput(": {},
         "commands.getstatusoutput(": {},
+	"eval(": {},
+	"exec(": {},
         "execute(": {},
         "filter(": {},
         "flash(": {},


### PR DESCRIPTION
In #200 some sinks were added for shell injection.  This adds 'exec' and 'eval', the built-in keywords, to the list.