### PR TITLE
docs: fix simple typo, traveral -> traversal

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Static analysis of Python web applications based on theoretical foundations (Con
 Features
 --------
 
-* Detect command injection, SSRF, SQL injection, XSS, directory traveral etc.
+* Detect command injection, SSRF, SQL injection, XSS, directory traversal etc.
 
 * A lot of customisation possible
 


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `traversal` rather than `traveral`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md